### PR TITLE
chore: form errors - subtle in animation

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^4.1.3",
-    "@iress-oss/ids-components": "^6.0.0-alpha.2",
+    "@iress-oss/ids-components": "^6.0.0-alpha.3",
     "@iress-oss/ids-storybook-config": "^0.2.0",
     "@iress-oss/ids-storybook-okta": "^0.1.1",
     "@iress-oss/ids-storybook-sandbox": "^0.2.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iress-oss/ids-components",
-  "version": "6.0.0-alpha.2",
+  "version": "6.0.0-alpha.3",
   "description": "Iress React Component Library",
   "license": "Apache-2.0",
   "type": "module",
@@ -83,5 +83,6 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/iress/design-system"
-  }
+  },
+  "stableVersion": "6.0.0-alpha.2"
 }

--- a/packages/components/theme-preset/tokens/keyframes.ts
+++ b/packages/components/theme-preset/tokens/keyframes.ts
@@ -1,8 +1,13 @@
+import { cssVars } from '@iress-oss/ids-tokens';
 import { defineKeyframes } from '@pandacss/dev';
 
 export const keyframes = defineKeyframes({
   fieldFooter: {
-    '0%': { display: 'none', opacity: 0, transform: 'translateY(-100%)' },
+    '0%': {
+      display: 'none',
+      opacity: 0,
+      transform: `translateY(calc(${cssVars.spacing[2]} * -1))`,
+    },
     '100%': { display: 'block', opacity: 1, transform: 'translateY(0)' },
   },
   iconRotation: {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iress-oss/ids-mcp-server",
-  "version": "6.0.0-alpha.2",
+  "version": "6.0.0-alpha.3",
   "description": "Model Context Protocol (MCP) server for Iress Design System (IDS) component library - provides AI assistants with contextual information about IDS components, design tokens, and usage patterns",
   "type": "module",
   "main": "./dist/index.js",
@@ -58,5 +58,6 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/iress/design-system"
-  }
+  },
+  "stableVersion": "6.0.0-alpha.2"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1799,7 +1799,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@iress-oss/ids-components@npm:^6.0.0-alpha.2, @iress-oss/ids-components@workspace:packages/components":
+"@iress-oss/ids-components@npm:^6.0.0-alpha.3, @iress-oss/ids-components@workspace:packages/components":
   version: 0.0.0-use.local
   resolution: "@iress-oss/ids-components@workspace:packages/components"
   dependencies:
@@ -2151,7 +2151,7 @@ __metadata:
   resolution: "@iress/design-system-monorepo@workspace:."
   dependencies:
     "@chromatic-com/storybook": "npm:^4.1.3"
-    "@iress-oss/ids-components": "npm:^6.0.0-alpha.2"
+    "@iress-oss/ids-components": "npm:^6.0.0-alpha.3"
     "@iress-oss/ids-storybook-config": "npm:^0.2.0"
     "@iress-oss/ids-storybook-okta": "npm:^0.1.1"
     "@iress-oss/ids-storybook-sandbox": "npm:^0.2.0"


### PR DESCRIPTION
This pull request primarily updates package versions across the monorepo to `6.0.0-alpha.3` and introduces a small improvement to the keyframe animation tokens. The changes ensure that dependencies are aligned and add a new metadata field for stable versions in package manifests.

Version updates and metadata:

* Bump version of `@iress-oss/ids-components` and `@iress-oss/ids-mcp-server` to `6.0.0-alpha.3` in their respective `package.json` files, and update the dependency in the root `package.json` to match. [[1]](diffhunk://#diff-2c76dc06185f93bec73660e15338433b95eac6707317564c0f778f5b9abe446cL3-R3) [[2]](diffhunk://#diff-990360a4804119958cc0f1eef2aa3cd1668695f18a77511106db3ad1556a9a21L3-R3) [[3]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L15-R15)
* Add a `stableVersion` field to `packages/components/package.json` and `packages/mcp-server/package.json` to track the last stable release. [[1]](diffhunk://#diff-2c76dc06185f93bec73660e15338433b95eac6707317564c0f778f5b9abe446cL86-R87) [[2]](diffhunk://#diff-990360a4804119958cc0f1eef2aa3cd1668695f18a77511106db3ad1556a9a21L61-R62)

Keyframe animation improvement:

* Update the `fieldFooter` keyframe in `theme-preset/tokens/keyframes.ts` to use the spacing value from `cssVars` for the Y translation, making the animation spacing consistent with the design system tokens.