### PR TITLE
feat: enhance IressFormField render prop with form state

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^4.1.3",
-    "@iress-oss/ids-components": "^6.0.0-alpha.4",
+    "@iress-oss/ids-components": "^6.0.0-alpha.5",
     "@iress-oss/ids-storybook-config": "^0.2.1",
     "@iress-oss/ids-storybook-okta": "^0.1.1",
     "@iress-oss/ids-storybook-sandbox": "^0.2.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iress-oss/ids-components",
-  "version": "6.0.0-alpha.4",
+  "version": "6.0.0-alpha.5",
   "description": "Iress React Component Library",
   "license": "Apache-2.0",
   "type": "module",
@@ -99,5 +99,6 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/iress/design-system"
-  }
+  },
+  "stableVersion": "6.0.0-alpha.4"
 }

--- a/packages/components/src/patterns/Form/FormField/FormField.tsx
+++ b/packages/components/src/patterns/Form/FormField/FormField.tsx
@@ -1,12 +1,14 @@
 import { type ReactNode, useContext, useEffect, useMemo, useRef } from 'react';
 import {
   type Control,
+  type ControllerFieldState,
   type ControllerRenderProps,
   type FieldPath,
   type FieldPathValue,
   type FieldValues,
   useController,
   type UseControllerProps,
+  type UseFormStateReturn,
 } from 'react-hook-form';
 import {
   type FormFieldErrorType,
@@ -48,7 +50,10 @@ export interface IressFormFieldProps<
    * To ensure the field is correctly registered with the form, the control must be passed as props to the rendered component.
    * (eg. `render={field => <IressInput {...field} />}`)
    */
-  render: (field: FormFieldRenderProps<T>) => ReactNode;
+  render: (
+    field: FormFieldRenderProps<T>,
+    state: FormFieldRenderState<T>,
+  ) => ReactNode;
 
   /**
    * Validation rules, including: required, min, max, minLength, maxLength, pattern, validate
@@ -77,6 +82,21 @@ export interface FormFieldRenderProps<T extends FieldValues>
    * ID of the field. It is automatically generated based on the name of the field and its parent form.
    */
   id: string;
+}
+
+/**
+ * Props for the `IressFormField` `render` prop, second argument.
+ */
+export interface FormFieldRenderState<T extends FieldValues> {
+  /**
+   * State of the field.
+   */
+  fieldState?: ControllerFieldState;
+
+  /**
+   * State of the form.
+   */
+  formState?: UseFormStateReturn<T>;
 }
 
 /**
@@ -109,7 +129,7 @@ export const IressFormField = <T extends FieldValues>({
       : undefined;
   }, [readOnly, withCustomRules]);
 
-  const { field, fieldState } = useController<T>({
+  const { field, formState, fieldState } = useController<T>({
     control,
     defaultValue,
     name,
@@ -149,10 +169,16 @@ export const IressFormField = <T extends FieldValues>({
       htmlFor={`${form.id}__${name}`}
       {...fieldProps}
     >
-      {render({
-        ...renderField,
-        id: `${form.id}__${name}`,
-      })}
+      {render(
+        {
+          ...renderField,
+          id: `${form.id}__${name}`,
+        },
+        {
+          formState,
+          fieldState,
+        },
+      )}
     </IressField>
   );
 };

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iress-oss/ids-mcp-server",
-  "version": "6.0.0-alpha.4",
+  "version": "6.0.0-alpha.5",
   "description": "Model Context Protocol (MCP) server for Iress Design System (IDS) component library - provides AI assistants with contextual information about IDS components, design tokens, and usage patterns",
   "type": "module",
   "main": "./dist/index.js",
@@ -58,5 +58,6 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/iress/design-system"
-  }
+  },
+  "stableVersion": "6.0.0-alpha.4"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1799,7 +1799,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@iress-oss/ids-components@npm:^6.0.0-alpha.4, @iress-oss/ids-components@workspace:packages/components":
+"@iress-oss/ids-components@npm:^6.0.0-alpha.5, @iress-oss/ids-components@workspace:packages/components":
   version: 0.0.0-use.local
   resolution: "@iress-oss/ids-components@workspace:packages/components"
   dependencies:
@@ -2162,7 +2162,7 @@ __metadata:
   resolution: "@iress/design-system-monorepo@workspace:."
   dependencies:
     "@chromatic-com/storybook": "npm:^4.1.3"
-    "@iress-oss/ids-components": "npm:^6.0.0-alpha.4"
+    "@iress-oss/ids-components": "npm:^6.0.0-alpha.5"
     "@iress-oss/ids-storybook-config": "npm:^0.2.1"
     "@iress-oss/ids-storybook-okta": "npm:^0.1.1"
     "@iress-oss/ids-storybook-sandbox": "npm:^0.2.1"
@@ -3022,9 +3022,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@puppeteer/browsers@npm:2.11.0":
-  version: 2.11.0
-  resolution: "@puppeteer/browsers@npm:2.11.0"
+"@puppeteer/browsers@npm:2.10.13":
+  version: 2.10.13
+  resolution: "@puppeteer/browsers@npm:2.10.13"
   dependencies:
     debug: "npm:^4.4.3"
     extract-zip: "npm:^2.0.1"
@@ -3035,7 +3035,7 @@ __metadata:
     yargs: "npm:^17.7.2"
   bin:
     browsers: lib/cjs/main-cli.js
-  checksum: 10c0/4c8cb0de98c9f2c1f4e987fbb1f95fe500a89845927610af2de23e969912fab5a9791c4729d2d86686812564e00ba4efaff900997ad2a5a2e1c57fb41286b8ca
+  checksum: 10c0/b6e003649f5d5231fa8c3aab32423cd3f89cdacc4cf8cf7e0e85b40c53858b09be4c5daf32bbbe481bdaaee1bc28bc78bfb5c19495de8d8736c9728ec25b7a02
   languageName: node
   linkType: hard
 
@@ -6946,10 +6946,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"devtools-protocol@npm:0.0.1534754":
-  version: 0.0.1534754
-  resolution: "devtools-protocol@npm:0.0.1534754"
-  checksum: 10c0/2ee96f10c9833f7e6ad0f9f66e42242129547e96c8cfe816ce508c222f4ccf4431a4b787cd6ee8174c9b2c8cc9a3c7f3b3b0a1fff96dd3cc5a16eb314027c9f7
+"devtools-protocol@npm:0.0.1521046":
+  version: 0.0.1521046
+  resolution: "devtools-protocol@npm:0.0.1521046"
+  checksum: 10c0/ba4b83a94e2b9c26772b22a8f6029ff296976a72db8e4567c9076393fccc39a452f6c0530869eebe2e1ad483db0e6233cd6b7b723ce466a05660c758f5e06db0
   languageName: node
   linkType: hard
 
@@ -12571,34 +12571,34 @@ __metadata:
   languageName: node
   linkType: hard
 
-"puppeteer-core@npm:24.32.0":
-  version: 24.32.0
-  resolution: "puppeteer-core@npm:24.32.0"
+"puppeteer-core@npm:24.31.0":
+  version: 24.31.0
+  resolution: "puppeteer-core@npm:24.31.0"
   dependencies:
-    "@puppeteer/browsers": "npm:2.11.0"
+    "@puppeteer/browsers": "npm:2.10.13"
     chromium-bidi: "npm:11.0.0"
     debug: "npm:^4.4.3"
-    devtools-protocol: "npm:0.0.1534754"
+    devtools-protocol: "npm:0.0.1521046"
     typed-query-selector: "npm:^2.12.0"
     webdriver-bidi-protocol: "npm:0.3.9"
     ws: "npm:^8.18.3"
-  checksum: 10c0/1b1b7a5288d9b3a3f9cc6b81a31775cdfaf62f567956e401d1b9dd55ecedbe4bef9552d261dc0acb1f2213ee94e893315c22582654d1c00ca41d564a8244508d
+  checksum: 10c0/fc1941f31e9f960e70980833bd3e2af7a434d29311f6e345c14e29f849227d541da414fc77768814c2ca7e614289f2ce5edf8f6144963cfa1801827bb8a51cfc
   languageName: node
   linkType: hard
 
 "puppeteer@npm:^24.31.0":
-  version: 24.32.0
-  resolution: "puppeteer@npm:24.32.0"
+  version: 24.31.0
+  resolution: "puppeteer@npm:24.31.0"
   dependencies:
-    "@puppeteer/browsers": "npm:2.11.0"
+    "@puppeteer/browsers": "npm:2.10.13"
     chromium-bidi: "npm:11.0.0"
     cosmiconfig: "npm:^9.0.0"
-    devtools-protocol: "npm:0.0.1534754"
-    puppeteer-core: "npm:24.32.0"
+    devtools-protocol: "npm:0.0.1521046"
+    puppeteer-core: "npm:24.31.0"
     typed-query-selector: "npm:^2.12.0"
   bin:
     puppeteer: lib/cjs/puppeteer/node/cli.js
-  checksum: 10c0/99532667d481bfc473247bcf0fa250936ae9cdfe05d373b8454a5cf04b1225a388ae68d5377fdad26f7b20ea184c74b76a9747f8f01f40416e16d0be2c006777
+  checksum: 10c0/7b48fbd4efbc4e5a63c760f6047fe76f1dbff2ae7e9c089791b2ea348d7c8df53389c6d3be4c6687e84b8c55eeec8cd3341b42af376110964aa26d66474f9021
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This pull request updates the version of `@iress-oss/ids-components` and related packages to `6.0.0-alpha.5` and introduces an enhancement to the `IressFormField` component, allowing the render function to receive additional state information. The changes improve form field rendering flexibility and add metadata to package manifests.

**Component API Enhancement:**

* The `IressFormField` component's `render` prop now accepts a second argument with field and form state, enabling more advanced rendering logic based on validation and form status. [[1]](diffhunk://#diff-1a3c651c3449d938e6cd57745c33e8affed21a85d151662052ddec4d5fc410ddL51-R56) [[2]](diffhunk://#diff-1a3c651c3449d938e6cd57745c33e8affed21a85d151662052ddec4d5fc410ddR87-R101) [[3]](diffhunk://#diff-1a3c651c3449d938e6cd57745c33e8affed21a85d151662052ddec4d5fc410ddL112-R132) [[4]](diffhunk://#diff-1a3c651c3449d938e6cd57745c33e8affed21a85d151662052ddec4d5fc410ddL152-R181) [[5]](diffhunk://#diff-1a3c651c3449d938e6cd57745c33e8affed21a85d151662052ddec4d5fc410ddR4-R11)

**Package Version Updates:**

* Updated the version of `@iress-oss/ids-components` in both the root `package.json` and `packages/components/package.json` to `6.0.0-alpha.5`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L15-R15) [[2]](diffhunk://#diff-2c76dc06185f93bec73660e15338433b95eac6707317564c0f778f5b9abe446cL3-R3)
* Updated the version of `@iress-oss/ids-mcp-server` in `packages/mcp-server/package.json` to `6.0.0-alpha.5`.

**Package Metadata:**

* Added a new `stableVersion` field to `packages/components/package.json` and `packages/mcp-server/package.json` to track the last stable version. [[1]](diffhunk://#diff-2c76dc06185f93bec73660e15338433b95eac6707317564c0f778f5b9abe446cL102-R103) [[2]](diffhunk://#diff-990360a4804119958cc0f1eef2aa3cd1668695f18a77511106db3ad1556a9a21L61-R62)