### PR TITLE
chore: update @iress-oss/ids-tokens to version 6.0.0-alpha.3 in package.json and yarn.lock

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -29,7 +29,7 @@
     "typecheck:node": "tsc --noEmit -p tsconfig.node.json"
   },
   "devDependencies": {
-    "@iress-oss/ids-tokens": "^6.0.0-alpha.2",
+    "@iress-oss/ids-tokens": "^6.0.0-alpha.3",
     "@pandacss/dev": "1.5.1",
     "@testing-library/dom": "10.4.1",
     "@testing-library/jest-dom": "6.9.1",

--- a/packages/storybook-config/package.json
+++ b/packages/storybook-config/package.json
@@ -42,7 +42,7 @@
     "watch": "vite build --watch"
   },
   "dependencies": {
-    "@iress-oss/ids-tokens": "^6.0.0-alpha.2",
+    "@iress-oss/ids-tokens": "^6.0.0-alpha.3",
     "radash": "12.1.1",
     "react-diff-viewer": "^3.1.1",
     "react-element-to-jsx-string": "^17.0.1",

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -1,12 +1,13 @@
 {
   "name": "@iress-oss/ids-tokens",
-  "version": "6.0.0-alpha.2",
+  "version": "6.0.0-alpha.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
     ".": "./dist/index.js",
-    "./mapTokensToCssVariables": "./dist/helpers/mapTokensToCssVariables.js"
+    "./mapTokensToCssVariables": "./dist/helpers/mapTokensToCssVariables.js",
+    "./convertReferencesToVariables": "./dist/helpers/convertReferencesToVariables.js"
   },
   "files": [
     "build",
@@ -77,5 +78,6 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/iress/design-system"
-  }
+  },
+  "stableVersion": "6.0.0-alpha.2"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1805,7 +1805,7 @@ __metadata:
   dependencies:
     "@floating-ui/react": "npm:0.27.16"
     "@fortawesome/fontawesome-common-types": "npm:0.2.36"
-    "@iress-oss/ids-tokens": "npm:^6.0.0-alpha.2"
+    "@iress-oss/ids-tokens": "npm:^6.0.0-alpha.3"
     "@pandacss/dev": "npm:1.5.1"
     "@tanstack/react-table": "npm:8.21.3"
     "@testing-library/dom": "npm:10.4.1"
@@ -1897,7 +1897,7 @@ __metadata:
     "@iress-oss/ids-storybook-sandbox": "npm:^0.2.1"
     "@iress-oss/ids-storybook-toggle-stories": "npm:^0.1.0"
     "@iress-oss/ids-storybook-version-badge": "npm:^0.1.0"
-    "@iress-oss/ids-tokens": "npm:^6.0.0-alpha.2"
+    "@iress-oss/ids-tokens": "npm:^6.0.0-alpha.3"
     "@storybook/addon-a11y": "npm:10.0.8"
     "@storybook/addon-docs": "npm:10.0.8"
     "@storybook/addon-links": "npm:10.0.8"
@@ -2110,7 +2110,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@iress-oss/ids-tokens@npm:^6.0.0-alpha.2, @iress-oss/ids-tokens@workspace:packages/tokens":
+"@iress-oss/ids-tokens@npm:^6.0.0-alpha.3, @iress-oss/ids-tokens@workspace:packages/tokens":
   version: 0.0.0-use.local
   resolution: "@iress-oss/ids-tokens@workspace:packages/tokens"
   dependencies:


### PR DESCRIPTION
This pull request primarily updates the `@iress-oss/ids-tokens` package to version `6.0.0-alpha.3` across the codebase, and introduces a new export to the tokens package. Below are the most important changes:

Dependency updates:

* Updated the `@iress-oss/ids-tokens` dependency from `6.0.0-alpha.2` to `6.0.0-alpha.3` in both `packages/components/package.json` and `packages/storybook-config/package.json` to ensure all packages are using the latest version. [[1]](diffhunk://#diff-2c76dc06185f93bec73660e15338433b95eac6707317564c0f778f5b9abe446cL32-R32) [[2]](diffhunk://#diff-46d0795107ec547606361f1e84b021aec85532a321ea35e8823b9f3abd717276L45-R45)
* Bumped the version of the `@iress-oss/ids-tokens` package itself to `6.0.0-alpha.3` in its `package.json`.

Tokens package enhancements:

* Added a new export for `./convertReferencesToVariables` in the `exports` field of `@iress-oss/ids-tokens/package.json`, making this helper available for consumers of the package.
* Introduced a `stableVersion` field to `@iress-oss/ids-tokens/package.json` to track the last stable version.