### PR TITLE
fix: pass and load theme events not working

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@chromatic-com/storybook": "^4.1.3",
     "@iress-oss/ids-components": "^6.0.0-alpha.7",
-    "@iress-oss/ids-storybook-config": "^0.2.6",
+    "@iress-oss/ids-storybook-config": "^0.2.7",
     "@iress-oss/ids-storybook-okta": "^0.1.2",
     "@iress-oss/ids-storybook-sandbox": "^0.2.1",
     "@iress-oss/ids-storybook-toggle-stories": "^0.1.0",

--- a/packages/storybook-config/package.json
+++ b/packages/storybook-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iress-oss/ids-storybook-config",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/storybook-config/src/index.ts
+++ b/packages/storybook-config/src/index.ts
@@ -22,3 +22,10 @@ export * from './helpers/withTransformedSource';
 
 // Constants
 export * from './constants';
+
+// Types
+export type {
+  BroadcastHashEvent,
+  PassThemeEvent,
+  LoadThemeEvent,
+} from './types';

--- a/packages/storybook-config/src/main.stories.tsx
+++ b/packages/storybook-config/src/main.stories.tsx
@@ -1,0 +1,149 @@
+import {
+  IressButton,
+  IressInline,
+  IressPanel,
+  IressStack,
+} from '@iress-oss/ids-components';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useEffect, useState } from 'react';
+import { type BroadcastHashEvent } from './types';
+
+const MainStub = () => null;
+
+type Story = StoryObj<typeof MainStub>;
+
+// More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
+const meta: Meta<typeof MainStub> = {
+  title: 'Main',
+  component: MainStub,
+};
+
+export default meta;
+
+const Hash = () => {
+  const [broadcastHash, setBroadcastHash] = useState('');
+
+  useEffect(() => {
+    const saveParentHash = (event: MessageEvent<BroadcastHashEvent>) => {
+      if (event.data?.type !== 'UPDATE_HASH') {
+        return;
+      }
+
+      setBroadcastHash(event.data.hash);
+    };
+
+    window.addEventListener('message', saveParentHash);
+
+    return () => {
+      window.removeEventListener('message', saveParentHash);
+    };
+  }, []);
+
+  return (
+    <IressPanel bg="alt">
+      <p>
+        This story is to test the main Storybook configuration which broadcasts
+        theme changes via postMessage.
+      </p>
+      <p>
+        Parent window hash: <strong>{broadcastHash || 'N/A'}</strong>
+      </p>
+      <p>
+        <IressButton
+          onClick={() => {
+            window.parent.location.hash = String(Date.now());
+          }}
+        >
+          Trigger a hash change on parent window
+        </IressButton>
+      </p>
+    </IressPanel>
+  );
+};
+
+export const BroadcastHash: Story = {
+  render: () => <Hash />,
+};
+
+export const PassAndLoadTheme: Story = {
+  render: () => (
+    <IressStack gap="md">
+      <IressPanel bg="alt">
+        <p>
+          This story is to test the main Storybook configuration which passes
+          theme changes via postMessage. It is used to communicate theme changes
+          between Storybook compositions.
+        </p>
+        <IressInline gap="md">
+          <IressButton
+            onClick={() => {
+              // eslint-disable-next-line sonarjs/post-message
+              window.parent.postMessage(
+                {
+                  type: 'PASS_THEME',
+                  name: 'red-text',
+                  css: '.red-text { --iress-colour-neutral-80: red; }',
+                },
+                '*',
+              );
+            }}
+          >
+            Red theme
+          </IressButton>
+          <IressButton
+            onClick={() => {
+              // eslint-disable-next-line sonarjs/post-message
+              window.parent.postMessage(
+                {
+                  type: 'PASS_THEME',
+                  name: '',
+                },
+                '*',
+              );
+            }}
+          >
+            Clear
+          </IressButton>
+        </IressInline>
+      </IressPanel>
+      <IressPanel bg="alt">
+        <p>
+          Here you can also test sending theme changes from within the iframe
+          itself. You probably wouldn't do this in a real-world scenario, but
+          it's useful for testing.
+        </p>
+        <IressInline gap="md">
+          <IressButton
+            onClick={() => {
+              // eslint-disable-next-line sonarjs/post-message
+              window.postMessage(
+                {
+                  type: 'LOAD_THEME',
+                  name: 'blue-text',
+                  css: '.blue-text { --iress-colour-neutral-80: blue; }',
+                },
+                '*',
+              );
+            }}
+          >
+            Blue theme
+          </IressButton>
+          <IressButton
+            onClick={() => {
+              // eslint-disable-next-line sonarjs/post-message
+              window.postMessage(
+                {
+                  type: 'LOAD_THEME',
+                  name: '',
+                },
+                '*',
+              );
+            }}
+          >
+            Clear
+          </IressButton>
+        </IressInline>
+      </IressPanel>
+    </IressStack>
+  ),
+};

--- a/packages/storybook-config/src/main.ts
+++ b/packages/storybook-config/src/main.ts
@@ -207,7 +207,7 @@ export const getMainConfig = ({
         const frames = document.querySelectorAll('iframe');
         frames.forEach((f) => {
           try {
-            f.contentWindow?.postMessage({ type: 'LOAD_THEME', data }, '*');
+            f.contentWindow?.postMessage({ type: 'LOAD_THEME', ...data }, '*');
           } catch (err) {
             console.debug('[Storybook Host] Skipped frame broadcast:', err);
           }
@@ -233,29 +233,39 @@ export const getMainConfig = ({
 
         const { name, href, css } = event.data;
 
+        let existingHref = document.getElementById('storybook-config-theme-href');
+        let existingCss = document.getElementById('storybook-config-theme-css');
+        const existingTheme = document.documentElement.getAttribute('data-theme');
+
+        if (existingTheme) {
+          document.documentElement.classList.remove(existingTheme);
+        }
+
+        if (!name) {
+          existingHref?.remove();
+          existingCss?.remove();
+          return;
+        }
+
         if (href) {
-          const link = document.createElement('link');
-          link.rel = 'stylesheet';
-          link.href = href;
-          document.head.appendChild(link);
+          if (!existingHref) {
+            existingHref = document.createElement('link');
+            existingHref.rel = 'stylesheet';
+            existingHref.id = 'storybook-config-theme-href';
+            document.head.appendChild(existingHref);
+          }
+
+          existingHref.href = href;
         }
 
         if (css) {
-          const existing = document.head.querySelector('#storybook-config-theme);
-
-          if (!existing) {
-            const style = document.createElement('style');
-            style.id = 'storybook-config-theme';
-            document.head.appendChild(style);
+          if (!existingCss) {
+            existingCss = document.createElement('style');
+            existingCss.id = 'storybook-config-theme-css';
+            document.head.appendChild(existingCss);
           }
 
-          style.innerHTML = css;
-        }
-
-        const currentTheme = document.documentElement.getAttribute('data-theme');
-
-        if (currentTheme) {
-          document.documentElement.classList.remove(currentTheme);
+          existingCss.innerHTML = css;
         }
 
         document.documentElement.setAttribute('data-theme', name);

--- a/packages/storybook-config/src/types.ts
+++ b/packages/storybook-config/src/types.ts
@@ -14,3 +14,43 @@ export type ReactElementToJSXStringOptions = Exclude<
   Parameters<typeof reactElementToJSXString>[1],
   undefined
 >;
+
+/**
+ * Event for broadcasting hash changes from a parent window to an iframe Storybook instance.
+ * Used to communicate hash changes between Storybook compositions.
+ */
+export interface BroadcastHashEvent {
+  type: 'UPDATE_HASH';
+  hash: string;
+}
+
+/**
+ * Event for passing theme data between the parent window and iframe Storybook instances.
+ * Used to synchronize themes across Storybook compositions.
+ */
+export interface PassThemeEvent {
+  type: 'PASS_THEME';
+
+  /**
+   * Name of the theme.
+   */
+  name: string;
+
+  /**
+   * Optional href to a CSS file for the theme.
+   */
+  href?: string;
+
+  /**
+   * Optional raw CSS string for the theme.
+   */
+  css?: string;
+}
+
+/**
+ * Event for loading a theme in an iframe Storybook instance.
+ * Sent from the parent window to apply the selected theme.
+ */
+export interface LoadThemeEvent extends Omit<PassThemeEvent, 'type'> {
+  type: 'LOAD_THEME';
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1888,7 +1888,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@iress-oss/ids-storybook-config@npm:^0.2.6, @iress-oss/ids-storybook-config@workspace:packages/storybook-config":
+"@iress-oss/ids-storybook-config@npm:^0.2.7, @iress-oss/ids-storybook-config@workspace:packages/storybook-config":
   version: 0.0.0-use.local
   resolution: "@iress-oss/ids-storybook-config@workspace:packages/storybook-config"
   dependencies:
@@ -2163,7 +2163,7 @@ __metadata:
   dependencies:
     "@chromatic-com/storybook": "npm:^4.1.3"
     "@iress-oss/ids-components": "npm:^6.0.0-alpha.7"
-    "@iress-oss/ids-storybook-config": "npm:^0.2.6"
+    "@iress-oss/ids-storybook-config": "npm:^0.2.7"
     "@iress-oss/ids-storybook-okta": "npm:^0.1.2"
     "@iress-oss/ids-storybook-sandbox": "npm:^0.2.1"
     "@iress-oss/ids-storybook-toggle-stories": "npm:^0.1.0"


### PR DESCRIPTION
This pull request updates the Storybook configuration package to improve theme synchronization and communication between parent and iframe Storybook instances. The changes add new event types for broadcasting hash and theme changes, introduce test stories for these features, and refine the logic for applying themes dynamically. The package version is also bumped to reflect these enhancements.

**Theme synchronization and event handling:**

* Added new TypeScript event interfaces (`BroadcastHashEvent`, `PassThemeEvent`, `LoadThemeEvent`) to support communication of hash and theme changes between parent and iframe Storybook instances in `packages/storybook-config/src/types.ts`.
* Exported the new event types from the main package index for easier usage in consumers in `packages/storybook-config/src/index.ts`.
* Improved logic in `packages/storybook-config/src/main.ts` to cleanly apply and remove theme CSS or href, ensuring only one theme is active at a time and preventing style conflicts.
* Fixed broadcasting of theme data to iframes by spreading the theme data object in the postMessage payload in `packages/storybook-config/src/main.ts`.

**Testing and documentation:**

* Added `packages/storybook-config/src/main.stories.tsx` containing stories to test hash broadcasting and theme synchronization via postMessage, demonstrating usage of the new event types and theme switching logic.

**Dependency and version updates:**

* Bumped the package version of `@iress-oss/ids-storybook-config` to `0.2.7` in both `package.json` and `packages/storybook-config/package.json` to reflect the new features. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L16-R16) [[2]](diffhunk://#diff-46d0795107ec547606361f1e84b021aec85532a321ea35e8823b9f3abd717276L3-R3)