### PR TITLE
feat: add custom font loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@chromatic-com/storybook": "^4.1.3",
     "@iress-oss/ids-components": "^6.0.0-alpha.7",
-    "@iress-oss/ids-storybook-config": "^0.2.7",
+    "@iress-oss/ids-storybook-config": "^0.2.8",
     "@iress-oss/ids-storybook-okta": "^0.1.2",
     "@iress-oss/ids-storybook-sandbox": "^0.2.1",
     "@iress-oss/ids-storybook-toggle-stories": "^0.1.0",

--- a/packages/storybook-config/package.json
+++ b/packages/storybook-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iress-oss/ids-storybook-config",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/storybook-config/src/main.stories.tsx
+++ b/packages/storybook-config/src/main.stories.tsx
@@ -82,7 +82,10 @@ export const PassAndLoadTheme: Story = {
                 {
                   type: 'PASS_THEME',
                   name: 'red-text',
-                  css: '.red-text { --iress-colour-neutral-80: red; }',
+                  css: '.red-text { --iress-colour-neutral-80: red; --iress-typography-base-body-font: "Work Sans", sans-serif; }',
+                  fonts: [
+                    'https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=Ubuntu:ital,wght@0,300;0,400;0,500;0,700;1,300;1,400;1,500;1,700&family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap',
+                  ],
                 },
                 '*',
               );

--- a/packages/storybook-config/src/main.ts
+++ b/packages/storybook-config/src/main.ts
@@ -231,7 +231,7 @@ export const getMainConfig = ({
           return;
         }
 
-        const { name, href, css } = event.data;
+        const { name, href, css, fonts = [] } = event.data;
 
         let existingHref = document.getElementById('storybook-config-theme-href');
         let existingCss = document.getElementById('storybook-config-theme-css');
@@ -267,6 +267,19 @@ export const getMainConfig = ({
 
           existingCss.innerHTML = css;
         }
+
+        fonts?.forEach((font) => {
+          const existingFont = document.querySelector(\`link[href="\${font}"]\`);
+
+          if (existingFont) {
+            return;
+          }
+            
+          const link = document.createElement('link');
+          link.rel = 'stylesheet';
+          link.href = font;
+          document.head.appendChild(link);
+        });
 
         document.documentElement.setAttribute('data-theme', name);
         document.documentElement.classList.add(name);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1888,7 +1888,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@iress-oss/ids-storybook-config@npm:^0.2.7, @iress-oss/ids-storybook-config@workspace:packages/storybook-config":
+"@iress-oss/ids-storybook-config@npm:^0.2.8, @iress-oss/ids-storybook-config@workspace:packages/storybook-config":
   version: 0.0.0-use.local
   resolution: "@iress-oss/ids-storybook-config@workspace:packages/storybook-config"
   dependencies:
@@ -2163,7 +2163,7 @@ __metadata:
   dependencies:
     "@chromatic-com/storybook": "npm:^4.1.3"
     "@iress-oss/ids-components": "npm:^6.0.0-alpha.7"
-    "@iress-oss/ids-storybook-config": "npm:^0.2.7"
+    "@iress-oss/ids-storybook-config": "npm:^0.2.8"
     "@iress-oss/ids-storybook-okta": "npm:^0.1.2"
     "@iress-oss/ids-storybook-sandbox": "npm:^0.2.1"
     "@iress-oss/ids-storybook-toggle-stories": "npm:^0.1.0"


### PR DESCRIPTION
This pull request updates the Storybook theme configuration to support loading custom web fonts alongside CSS theme changes. The changes ensure that when a theme is applied, any specified fonts are dynamically loaded into the document. Additionally, the version of the `@iress-oss/ids-storybook-config` package is incremented to reflect these enhancements.

**Theme and font loading enhancements:**

* Added support for a `fonts` array in theme data, which allows specifying external font URLs to be loaded when a theme is applied. The code now dynamically injects `<link>` tags for these fonts if they are not already present in the document. (`packages/storybook-config/src/main.ts`, `packages/storybook-config/src/main.stories.tsx`) [[1]](diffhunk://#diff-bca2e1fa76cdb1602d977666e872d1dfbc35ef5cee98346762d3f7b8cf9b80a6L234-R234) [[2]](diffhunk://#diff-bca2e1fa76cdb1602d977666e872d1dfbc35ef5cee98346762d3f7b8cf9b80a6R271-R283) [[3]](diffhunk://#diff-d5703521d9fdbf9fa40127192e91caf6c3f4390828aa8d605e3dcb75d0f3922aL85-R88)
* Updated the sample theme in `PassAndLoadTheme` to include a `fonts` property and set a custom font via CSS variable. (`packages/storybook-config/src/main.stories.tsx`)

**Dependency and version updates:**

* Bumped the version of `@iress-oss/ids-storybook-config` to `0.2.8` in both its own `package.json` and the root `package.json` to reflect the new functionality. (`packages/storybook-config/package.json`, `package.json`) [[1]](diffhunk://#diff-46d0795107ec547606361f1e84b021aec85532a321ea35e8823b9f3abd717276L3-R3) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L16-R16)