### PR TITLE
feat: enhance version badge functionality with dynamic version retrieval and API integration

### DIFF
--- a/.storybook/manager.ts
+++ b/.storybook/manager.ts
@@ -1,6 +1,17 @@
 import { setUpManager } from '@iress-oss/ids-storybook-config/manager';
-import { version } from '../packages/components/package.json';
+import { version as componentsVersion } from '../packages/components/package.json';
+import { version as tokensVersion } from '../packages/tokens/package.json';
 
 setUpManager({
-  version,
+  version: (ref) => {
+    if (ref === 'components') {
+      return componentsVersion;
+    }
+
+    if (ref === 'tokens') {
+      return tokensVersion;
+    }
+
+    return '';
+  },
 });

--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
   "devDependencies": {
     "@chromatic-com/storybook": "^4.1.3",
     "@iress-oss/ids-components": "^6.0.0-alpha.7",
-    "@iress-oss/ids-storybook-config": "^0.2.8",
+    "@iress-oss/ids-storybook-config": "^0.2.9",
     "@iress-oss/ids-storybook-okta": "^0.1.2",
     "@iress-oss/ids-storybook-sandbox": "^0.2.1",
     "@iress-oss/ids-storybook-toggle-stories": "^0.1.0",
-    "@iress-oss/ids-storybook-version-badge": "^0.1.0",
+    "@iress-oss/ids-storybook-version-badge": "^0.1.1",
     "@mermaid-js/mermaid-cli": "^11.12.0",
     "@storybook/addon-a11y": "10.0.8",
     "@storybook/addon-docs": "10.0.8",

--- a/packages/storybook-config/package.json
+++ b/packages/storybook-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iress-oss/ids-storybook-config",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -53,7 +53,7 @@
     "@iress-oss/ids-storybook-okta": "^0.1.2",
     "@iress-oss/ids-storybook-sandbox": "^0.2.1",
     "@iress-oss/ids-storybook-toggle-stories": "^0.1.0",
-    "@iress-oss/ids-storybook-version-badge": "^0.1.0",
+    "@iress-oss/ids-storybook-version-badge": "^0.1.1",
     "@storybook/addon-a11y": "10.0.8",
     "@storybook/addon-docs": "10.0.8",
     "@storybook/addon-links": "10.0.8",

--- a/packages/storybook-config/src/manager.ts
+++ b/packages/storybook-config/src/manager.ts
@@ -21,7 +21,7 @@ interface ManagerProps {
   /**
    * The version to show in the version badge.
    */
-  version?: string;
+  version?: string | ((ref?: string) => Promise<string> | string);
 }
 
 /**

--- a/packages/storybook-version-badge/package.json
+++ b/packages/storybook-version-badge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iress-oss/ids-storybook-version-badge",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A Storybook addon that displays the current version of your design system in the Storybook toolbar.",
   "keywords": [
     "storybook-addons"

--- a/packages/storybook-version-badge/src/components/VersionBadge.test.tsx
+++ b/packages/storybook-version-badge/src/components/VersionBadge.test.tsx
@@ -2,6 +2,16 @@ import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import { VersionBadge } from './VersionBadge';
 import { ThemeProvider } from 'storybook/theming';
+import type { API } from 'storybook/manager-api';
+
+// Mock API for testing
+const createMockApi = (
+  urlState?: { path: string; viewMode: string },
+  refs?: Record<string, { id: string }>,
+): Partial<API> => ({
+  getUrlState: vi.fn(() => urlState) as never,
+  getRefs: vi.fn(() => refs ?? {}) as never,
+});
 
 // Test wrapper with ThemeProvider - similar to VersionBadge.stories.tsx
 const renderWithTheme = (ui: React.ReactElement) => {
@@ -25,22 +35,24 @@ const renderWithTheme = (ui: React.ReactElement) => {
 };
 
 describe('VersionBadge', () => {
-  describe('version handling', () => {
-    it('renders with default version when no version provided', () => {
-      renderWithTheme(<VersionBadge />);
+  const mockApi = createMockApi() as API;
 
-      expect(screen.getByText('0.0.0')).toBeInTheDocument();
+  describe('version handling', () => {
+    it('does not render when no version provided', () => {
+      renderWithTheme(<VersionBadge api={mockApi} />);
+
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
     });
 
     it('renders with string version', () => {
-      renderWithTheme(<VersionBadge version="1.2.3" />);
+      renderWithTheme(<VersionBadge api={mockApi} version="1.2.3" />);
 
       expect(screen.getByText('1.2.3')).toBeInTheDocument();
     });
 
     it('renders with function version that returns string', async () => {
       const versionFunction = vi.fn(() => '2.0.0');
-      renderWithTheme(<VersionBadge version={versionFunction} />);
+      renderWithTheme(<VersionBadge api={mockApi} version={versionFunction} />);
 
       await waitFor(() => {
         expect(screen.getByText('2.0.0')).toBeInTheDocument();
@@ -51,7 +63,7 @@ describe('VersionBadge', () => {
 
     it('renders with async function version', async () => {
       const versionFunction = vi.fn(async () => '3.0.0-beta');
-      renderWithTheme(<VersionBadge version={versionFunction} />);
+      renderWithTheme(<VersionBadge api={mockApi} version={versionFunction} />);
 
       await waitFor(() => {
         expect(screen.getByText('3.0.0-beta')).toBeInTheDocument();
@@ -62,7 +74,7 @@ describe('VersionBadge', () => {
 
     it('does not render when version function returns empty string', async () => {
       const versionFunction = vi.fn(() => '');
-      renderWithTheme(<VersionBadge version={versionFunction} />);
+      renderWithTheme(<VersionBadge api={mockApi} version={versionFunction} />);
 
       await waitFor(() => {
         expect(screen.queryByRole('button')).not.toBeInTheDocument();
@@ -72,7 +84,7 @@ describe('VersionBadge', () => {
     });
 
     it('does not render when version is empty string', () => {
-      renderWithTheme(<VersionBadge version="" />);
+      renderWithTheme(<VersionBadge api={mockApi} version="" />);
 
       expect(screen.queryByRole('button')).not.toBeInTheDocument();
     });
@@ -80,7 +92,7 @@ describe('VersionBadge', () => {
 
   describe('environment handling', () => {
     it('renders without environment badge when no environment provided', () => {
-      renderWithTheme(<VersionBadge version="1.0.0" />);
+      renderWithTheme(<VersionBadge api={mockApi} version="1.0.0" />);
 
       expect(screen.getByText('1.0.0')).toBeInTheDocument();
       // Check that there's only the version text, no environment text
@@ -90,7 +102,7 @@ describe('VersionBadge', () => {
 
     it('renders with string environment', () => {
       renderWithTheme(
-        <VersionBadge version="1.0.0" environment="production" />,
+        <VersionBadge api={mockApi} version="1.0.0" environment="production" />,
       );
 
       expect(screen.getByText('1.0.0')).toBeInTheDocument();
@@ -100,7 +112,11 @@ describe('VersionBadge', () => {
     it('renders with function environment that returns string', async () => {
       const environmentFunction = vi.fn(() => 'staging');
       renderWithTheme(
-        <VersionBadge version="1.0.0" environment={environmentFunction} />,
+        <VersionBadge
+          api={mockApi}
+          version="1.0.0"
+          environment={environmentFunction}
+        />,
       );
 
       await waitFor(() => {
@@ -113,7 +129,11 @@ describe('VersionBadge', () => {
     it('renders with async function environment', async () => {
       const environmentFunction = vi.fn(async () => 'development');
       renderWithTheme(
-        <VersionBadge version="1.0.0" environment={environmentFunction} />,
+        <VersionBadge
+          api={mockApi}
+          version="1.0.0"
+          environment={environmentFunction}
+        />,
       );
 
       await waitFor(() => {
@@ -126,7 +146,11 @@ describe('VersionBadge', () => {
     it('does not render environment badge when environment function returns empty string', async () => {
       const environmentFunction = vi.fn(() => '');
       renderWithTheme(
-        <VersionBadge version="1.0.0" environment={environmentFunction} />,
+        <VersionBadge
+          api={mockApi}
+          version="1.0.0"
+          environment={environmentFunction}
+        />,
       );
 
       await waitFor(() => {
@@ -141,7 +165,9 @@ describe('VersionBadge', () => {
     });
 
     it('does not render environment badge when environment is empty string', () => {
-      renderWithTheme(<VersionBadge version="1.0.0" environment="" />);
+      renderWithTheme(
+        <VersionBadge api={mockApi} version="1.0.0" environment="" />,
+      );
 
       expect(screen.getByText('1.0.0')).toBeInTheDocument();
       // Check that there's no common environment text rendered
@@ -154,7 +180,7 @@ describe('VersionBadge', () => {
   describe('combined version and environment', () => {
     it('renders both version and environment when provided', () => {
       renderWithTheme(
-        <VersionBadge version="1.0.0" environment="production" />,
+        <VersionBadge api={mockApi} version="1.0.0" environment="production" />,
       );
 
       expect(screen.getByText('1.0.0')).toBeInTheDocument();
@@ -167,6 +193,7 @@ describe('VersionBadge', () => {
 
       renderWithTheme(
         <VersionBadge
+          api={mockApi}
           version={versionFunction}
           environment={environmentFunction}
         />,
@@ -185,7 +212,11 @@ describe('VersionBadge', () => {
       const environmentFunction = vi.fn(async () => 'qa');
 
       renderWithTheme(
-        <VersionBadge version="1.5.0" environment={environmentFunction} />,
+        <VersionBadge
+          api={mockApi}
+          version="1.5.0"
+          environment={environmentFunction}
+        />,
       );
 
       expect(screen.getByText('1.5.0')).toBeInTheDocument();
@@ -200,21 +231,23 @@ describe('VersionBadge', () => {
 
   describe('component structure', () => {
     it('renders with correct CSS class', () => {
-      renderWithTheme(<VersionBadge version="1.0.0" />);
+      renderWithTheme(<VersionBadge api={mockApi} version="1.0.0" />);
 
       const container = document.querySelector('.version-badge');
       expect(container).toBeInTheDocument();
     });
 
     it('renders badge component with correct content', () => {
-      renderWithTheme(<VersionBadge version="1.0.0" />);
+      renderWithTheme(<VersionBadge api={mockApi} version="1.0.0" />);
 
       // Check that the badge is rendered with the correct version
       expect(screen.getByText('1.0.0')).toBeInTheDocument();
     });
 
     it('renders environment badge with correct styling when environment provided', () => {
-      renderWithTheme(<VersionBadge version="1.0.0" environment="test" />);
+      renderWithTheme(
+        <VersionBadge api={mockApi} version="1.0.0" environment="test" />,
+      );
 
       // Check that both version and environment are rendered
       expect(screen.getByText('1.0.0')).toBeInTheDocument();
@@ -228,7 +261,7 @@ describe('VersionBadge', () => {
       const versionFunction2 = vi.fn(() => '2.0.0');
 
       const { rerender } = renderWithTheme(
-        <VersionBadge version={versionFunction1} />,
+        <VersionBadge api={mockApi} version={versionFunction1} />,
       );
 
       await waitFor(() => {
@@ -249,7 +282,7 @@ describe('VersionBadge', () => {
             } as never,
           }}
         >
-          <VersionBadge version={versionFunction2} />
+          <VersionBadge api={mockApi} version={versionFunction2} />
         </ThemeProvider>,
       );
 
@@ -266,7 +299,11 @@ describe('VersionBadge', () => {
       const environmentFunction2 = vi.fn(() => 'prod');
 
       const { rerender } = renderWithTheme(
-        <VersionBadge version="1.0.0" environment={environmentFunction1} />,
+        <VersionBadge
+          api={mockApi}
+          version="1.0.0"
+          environment={environmentFunction1}
+        />,
       );
 
       await waitFor(() => {
@@ -287,7 +324,11 @@ describe('VersionBadge', () => {
             } as never,
           }}
         >
-          <VersionBadge version="1.0.0" environment={environmentFunction2} />
+          <VersionBadge
+            api={mockApi}
+            version="1.0.0"
+            environment={environmentFunction2}
+          />
         </ThemeProvider>,
       );
 
@@ -297,6 +338,160 @@ describe('VersionBadge', () => {
 
       expect(environmentFunction1).toHaveBeenCalledTimes(1);
       expect(environmentFunction2).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('API integration and ref handling', () => {
+    it('passes undefined ref when URL state is not available', async () => {
+      const versionFunction = vi.fn(() => '1.0.0');
+      const apiWithoutUrlState = createMockApi(undefined, {}) as API;
+
+      renderWithTheme(
+        <VersionBadge api={apiWithoutUrlState} version={versionFunction} />,
+      );
+
+      await waitFor(() => {
+        expect(versionFunction).toHaveBeenCalledWith(undefined);
+      });
+    });
+
+    it('passes undefined ref when no matching ref is found', async () => {
+      const versionFunction = vi.fn(() => '1.0.0');
+      const apiWithNonMatchingRef = createMockApi(
+        { path: '/docs/some-story', viewMode: 'docs' },
+        { otherRef: { id: 'other' } },
+      ) as API;
+
+      renderWithTheme(
+        <VersionBadge api={apiWithNonMatchingRef} version={versionFunction} />,
+      );
+
+      await waitFor(() => {
+        expect(versionFunction).toHaveBeenCalledWith(undefined);
+      });
+    });
+
+    it('extracts and passes current ref ID when path matches a ref', async () => {
+      const versionFunction = vi.fn((ref?: string) =>
+        ref === 'my-ref' ? '2.0.0' : '1.0.0',
+      );
+      const apiWithMatchingRef = createMockApi(
+        { path: '/docs/my-ref_some-story', viewMode: 'docs' },
+        { myRef: { id: 'my-ref' } },
+      ) as API;
+
+      renderWithTheme(
+        <VersionBadge api={apiWithMatchingRef} version={versionFunction} />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('2.0.0')).toBeInTheDocument();
+      });
+
+      expect(versionFunction).toHaveBeenCalledWith('my-ref');
+    });
+
+    it('handles multiple refs and matches the correct one', async () => {
+      const versionFunction = vi.fn((ref?: string) => {
+        if (ref === 'ref-a') return '1.0.0';
+        if (ref === 'ref-b') return '2.0.0';
+        return '0.0.0';
+      });
+
+      const apiWithMultipleRefs = createMockApi(
+        { path: '/story/ref-b_some-component', viewMode: 'story' },
+        {
+          refA: { id: 'ref-a' },
+          refB: { id: 'ref-b' },
+          refC: { id: 'ref-c' },
+        },
+      ) as API;
+
+      renderWithTheme(
+        <VersionBadge api={apiWithMultipleRefs} version={versionFunction} />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('2.0.0')).toBeInTheDocument();
+      });
+
+      expect(versionFunction).toHaveBeenCalledWith('ref-b');
+    });
+
+    it('updates version when ref changes via navigation', async () => {
+      const versionFunction = vi.fn((ref?: string) => {
+        if (ref === 'ref-a') return '1.0.0';
+        if (ref === 'ref-b') return '2.0.0';
+        return '0.0.0';
+      });
+
+      const refs = {
+        refA: { id: 'ref-a' },
+        refB: { id: 'ref-b' },
+      };
+
+      const apiRefA = createMockApi(
+        { path: '/docs/ref-a_story', viewMode: 'docs' },
+        refs,
+      ) as API;
+
+      const { rerender } = renderWithTheme(
+        <VersionBadge api={apiRefA} version={versionFunction} />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('1.0.0')).toBeInTheDocument();
+      });
+
+      // Simulate navigation to different ref
+      const apiRefB = createMockApi(
+        { path: '/docs/ref-b_story', viewMode: 'docs' },
+        refs,
+      ) as API;
+
+      rerender(
+        <ThemeProvider
+          theme={{
+            textMutedColor: '#6f6f6f',
+            typography: {
+              size: {
+                s1: 12,
+              } as never,
+              weight: {
+                bold: 600,
+              } as never,
+            } as never,
+          }}
+        >
+          <VersionBadge api={apiRefB} version={versionFunction} />
+        </ThemeProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('2.0.0')).toBeInTheDocument();
+      });
+    });
+
+    it('handles async version function with ref parameter', async () => {
+      const versionFunction = vi.fn(async (ref?: string) => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        return ref === 'my-ref' ? '3.0.0-async' : '1.0.0-async';
+      });
+
+      const apiWithRef = createMockApi(
+        { path: '/story/my-ref_component', viewMode: 'story' },
+        { myRef: { id: 'my-ref' } },
+      ) as API;
+
+      renderWithTheme(
+        <VersionBadge api={apiWithRef} version={versionFunction} />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('3.0.0-async')).toBeInTheDocument();
+      });
+
+      expect(versionFunction).toHaveBeenCalledWith('my-ref');
     });
   });
 });

--- a/packages/storybook-version-badge/src/manager.tsx
+++ b/packages/storybook-version-badge/src/manager.tsx
@@ -5,7 +5,7 @@ import { ADDON_ID, ADDON_TITLE } from './constants';
 import { VersionBadge } from './components/VersionBadge';
 import { type AddonConfig } from './types';
 
-addons.register(ADDON_ID, () => {
+addons.register(ADDON_ID, (api) => {
   const addonConfig = addons.getConfig()[ADDON_ID] as AddonConfig;
 
   if (!addonConfig) {
@@ -15,6 +15,6 @@ addons.register(ADDON_ID, () => {
   addons.add(ADDON_ID, {
     type: Addon_TypesEnum.TOOLEXTRA,
     title: ADDON_TITLE,
-    render: () => <VersionBadge {...addonConfig} />,
+    render: () => <VersionBadge {...addonConfig} api={api} />,
   });
 });

--- a/packages/storybook-version-badge/src/types.ts
+++ b/packages/storybook-version-badge/src/types.ts
@@ -9,5 +9,5 @@ export interface AddonConfig {
    * The version to display in the badge.
    * If a function is provided, it will be called to get the version string (you can use this to fetch the version dynamically).
    */
-  version?: string | (() => Promise<string> | string);
+  version?: string | ((ref?: string) => Promise<string> | string);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1888,7 +1888,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@iress-oss/ids-storybook-config@npm:^0.2.8, @iress-oss/ids-storybook-config@workspace:packages/storybook-config":
+"@iress-oss/ids-storybook-config@npm:^0.2.9, @iress-oss/ids-storybook-config@workspace:packages/storybook-config":
   version: 0.0.0-use.local
   resolution: "@iress-oss/ids-storybook-config@workspace:packages/storybook-config"
   dependencies:
@@ -1896,7 +1896,7 @@ __metadata:
     "@iress-oss/ids-storybook-okta": "npm:^0.1.2"
     "@iress-oss/ids-storybook-sandbox": "npm:^0.2.1"
     "@iress-oss/ids-storybook-toggle-stories": "npm:^0.1.0"
-    "@iress-oss/ids-storybook-version-badge": "npm:^0.1.0"
+    "@iress-oss/ids-storybook-version-badge": "npm:^0.1.1"
     "@iress-oss/ids-tokens": "npm:^6.0.0-alpha.4"
     "@storybook/addon-a11y": "npm:10.0.8"
     "@storybook/addon-docs": "npm:10.0.8"
@@ -2075,7 +2075,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@iress-oss/ids-storybook-version-badge@npm:^0.1.0, @iress-oss/ids-storybook-version-badge@workspace:packages/storybook-version-badge":
+"@iress-oss/ids-storybook-version-badge@npm:^0.1.1, @iress-oss/ids-storybook-version-badge@workspace:packages/storybook-version-badge":
   version: 0.0.0-use.local
   resolution: "@iress-oss/ids-storybook-version-badge@workspace:packages/storybook-version-badge"
   dependencies:
@@ -2163,11 +2163,11 @@ __metadata:
   dependencies:
     "@chromatic-com/storybook": "npm:^4.1.3"
     "@iress-oss/ids-components": "npm:^6.0.0-alpha.7"
-    "@iress-oss/ids-storybook-config": "npm:^0.2.8"
+    "@iress-oss/ids-storybook-config": "npm:^0.2.9"
     "@iress-oss/ids-storybook-okta": "npm:^0.1.2"
     "@iress-oss/ids-storybook-sandbox": "npm:^0.2.1"
     "@iress-oss/ids-storybook-toggle-stories": "npm:^0.1.0"
-    "@iress-oss/ids-storybook-version-badge": "npm:^0.1.0"
+    "@iress-oss/ids-storybook-version-badge": "npm:^0.1.1"
     "@mermaid-js/mermaid-cli": "npm:^11.12.0"
     "@storybook/addon-a11y": "npm:10.0.8"
     "@storybook/addon-docs": "npm:10.0.8"


### PR DESCRIPTION
This pull request introduces improvements to the Storybook version badge functionality, focusing on better support for multiple refs and dynamic version handling. The main changes include updating the version badge component and its tests to allow the version (and environment) to be determined by a function that receives the current ref, as well as updating dependencies to their latest versions.

**Version badge enhancements:**

* Updated the `VersionBadge` test suite to inject a mock Storybook API and test dynamic version and environment resolution based on the current ref, including scenarios with multiple refs and navigation between refs. [[1]](diffhunk://#diff-0c1d06ddf9156172a62db427793f0a881b567957f569f1771659ecaa56e3c73cR5-R14) [[2]](diffhunk://#diff-0c1d06ddf9156172a62db427793f0a881b567957f569f1771659ecaa56e3c73cR343-R496)
* Ensured the `VersionBadge` only renders when a valid version is provided, and correctly handles both synchronous and asynchronous version/environment functions. [[1]](diffhunk://#diff-0c1d06ddf9156172a62db427793f0a881b567957f569f1771659ecaa56e3c73cR38-R55) [[2]](diffhunk://#diff-0c1d06ddf9156172a62db427793f0a881b567957f569f1771659ecaa56e3c73cL54-R66) [[3]](diffhunk://#diff-0c1d06ddf9156172a62db427793f0a881b567957f569f1771659ecaa56e3c73cL65-R77) [[4]](diffhunk://#diff-0c1d06ddf9156172a62db427793f0a881b567957f569f1771659ecaa56e3c73cL75-R95) [[5]](diffhunk://#diff-0c1d06ddf9156172a62db427793f0a881b567957f569f1771659ecaa56e3c73cL93-R105) [[6]](diffhunk://#diff-0c1d06ddf9156172a62db427793f0a881b567957f569f1771659ecaa56e3c73cL103-R119) [[7]](diffhunk://#diff-0c1d06ddf9156172a62db427793f0a881b567957f569f1771659ecaa56e3c73cL116-R136) [[8]](diffhunk://#diff-0c1d06ddf9156172a62db427793f0a881b567957f569f1771659ecaa56e3c73cL129-R153) [[9]](diffhunk://#diff-0c1d06ddf9156172a62db427793f0a881b567957f569f1771659ecaa56e3c73cL144-R170) [[10]](diffhunk://#diff-0c1d06ddf9156172a62db427793f0a881b567957f569f1771659ecaa56e3c73cL157-R183) [[11]](diffhunk://#diff-0c1d06ddf9156172a62db427793f0a881b567957f569f1771659ecaa56e3c73cR196) [[12]](diffhunk://#diff-0c1d06ddf9156172a62db427793f0a881b567957f569f1771659ecaa56e3c73cL188-R219) [[13]](diffhunk://#diff-0c1d06ddf9156172a62db427793f0a881b567957f569f1771659ecaa56e3c73cL203-R250) [[14]](diffhunk://#diff-0c1d06ddf9156172a62db427793f0a881b567957f569f1771659ecaa56e3c73cL231-R264) [[15]](diffhunk://#diff-0c1d06ddf9156172a62db427793f0a881b567957f569f1771659ecaa56e3c73cL252-R285) [[16]](diffhunk://#diff-0c1d06ddf9156172a62db427793f0a881b567957f569f1771659ecaa56e3c73cL269-R306)

**API and configuration updates:**

* Modified the `ManagerProps` interface in `manager.ts` to allow the `version` property to be a function that receives an optional ref and returns a string or promise.
* Updated `.storybook/manager.ts` to support dynamic version selection for different refs (`components` and `tokens`).

**Dependency updates:**

* Bumped the versions of `@iress-oss/ids-storybook-config` and `@iress-oss/ids-storybook-version-badge` in `package.json` and related package files to ensure compatibility with new features. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L16-R20) [[2]](diffhunk://#diff-46d0795107ec547606361f1e84b021aec85532a321ea35e8823b9f3abd717276L3-R3) [[3]](diffhunk://#diff-46d0795107ec547606361f1e84b021aec85532a321ea35e8823b9f3abd717276L56-R56) [[4]](diffhunk://#diff-96e08bd9e55c4dd7376284118ee05123e01cbd47df4ee976b4e66279b0e0387aL3-R3)

These changes make the version badge more flexible and ref-aware, improving its accuracy and usefulness in multi-ref Storybook setups.