### PR TITLE
feat(FormField): add renderSupplementary prop for custom supplementary content

### DIFF
--- a/packages/components/src/components/Field/components/FieldFooter.tsx
+++ b/packages/components/src/components/Field/components/FieldFooter.tsx
@@ -46,17 +46,15 @@ export const FieldFooter = ({
 }: FieldFooterProps) => {
   const classes = field({ multipleFields });
   const elementRef = useRef<HTMLDivElement>(null);
-  const textContent = useRef<string | null>(null);
+  const previousHasError = useRef<boolean | null>(null);
   const hasError = useMemo(
     () => !!error || errorMessages.length > 0,
     [error, errorMessages.length],
   );
 
   useEffect(() => {
-    if (
-      !elementRef.current ||
-      elementRef.current.textContent === textContent.current
-    ) {
+    if (!elementRef.current || previousHasError.current === hasError) {
+      previousHasError.current = hasError;
       return;
     }
     elementRef.current.classList.remove(
@@ -65,10 +63,10 @@ export const FieldFooter = ({
 
     // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- Trigger reflow
     elementRef.current.offsetHeight;
-    textContent.current = elementRef.current.textContent;
+    previousHasError.current = hasError;
 
     elementRef.current.classList.add(css({ animationStyle: 'field-footer' }));
-  }, [supplementary, hasError]);
+  }, [hasError]);
 
   if (!supplementary && !hasError) {
     return null;

--- a/packages/components/src/patterns/Form/Form.docs.mdx
+++ b/packages/components/src/patterns/Form/Form.docs.mdx
@@ -174,6 +174,30 @@ Here are some examples of how to use `IressFormField` with different form contro
   }}
 />
 
+### Supplementary content
+
+The `renderSupplementary` prop allows you to render additional content alongside the field that has access to the field props and state. This is useful for displaying dynamic information such as character counters, password strength meters, or custom help text that responds to user input.
+
+The render function receives two arguments:
+
+1. `field`: An object containing the field props (id, name, value, onChange, onBlur, ref)
+2. `state`: An object containing the field state (fieldState, formState)
+
+Common use cases include:
+
+- **Character counters**: Display the current character count and maximum allowed
+- **Password strength indicators**: Show password strength based on the current value
+- **Dynamic hints**: Provide contextual help based on the field value
+- **Custom validation feedback**: Display real-time validation feedback separate from error messages
+
+<ComponentExample
+  of={FormFieldStories.RenderSupplementary}
+  story={{
+    inline: false,
+    height: '300px',
+  }}
+/>
+
 ### Rules
 
 Use the `rules` prop on the `IressFormField` component to add validation rules. These are based on the [rules available in React Hook Forms](https://www.react-hook-form.com/api/useform/register/#options). The following rules are supported.

--- a/packages/components/src/patterns/Form/FormField/FormField.stories.tsx
+++ b/packages/components/src/patterns/Form/FormField/FormField.stories.tsx
@@ -4,6 +4,7 @@ import {
   IressFormField,
   type IressFormFieldProps,
   IressInput,
+  IressText,
 } from '@/main';
 import {
   disableArgTypes,
@@ -14,7 +15,7 @@ import {
 type Story = StoryObj<typeof IressFormField>;
 
 export default {
-  title: 'Components/Form/FormField',
+  title: 'Patterns/Form/FormField',
   component: IressFormField,
   args: {
     label: 'Label',
@@ -47,3 +48,31 @@ export default {
 } as Meta<typeof IressFormField>;
 
 export const Default: Story = {};
+
+export const RenderSupplementary: Story = {
+  name: 'Supplementary content',
+  args: {
+    label: 'Comment',
+    name: 'comment',
+    hint: 'Enter your feedback (max 200 characters)',
+    render: (controlledProps) => (
+      <IressInput
+        {...controlledProps}
+        rows={3}
+        maxLength={200}
+        placeholder="Type your comment here..."
+      />
+    ),
+    renderSupplementary: ({ value }) => (
+      <IressText textStyle="typography.body.sm" color="muted">
+        {(value as string)?.length || 0} / 200 characters
+      </IressText>
+    ),
+    rules: {
+      maxLength: {
+        value: 200,
+        message: 'Comment must not exceed 200 characters',
+      },
+    },
+  },
+};

--- a/packages/components/src/patterns/Form/FormField/FormField.test.tsx
+++ b/packages/components/src/patterns/Form/FormField/FormField.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 
-import { IressFormField } from './FormField';
+import { IressFormField, IressFormFieldProps } from './FormField';
 import {
   IressButton,
   IressCheckbox,
@@ -142,6 +142,194 @@ describe('IressFormField', () => {
     expect(
       screen.queryByText('Label: This field is required'),
     ).not.toBeInTheDocument();
+  });
+
+  it('does not apply validation rules when readOnly is true', async () => {
+    const onSubmit = vi.fn();
+    const onError = vi.fn();
+
+    render(
+      <IressForm id="iress-form" onSubmit={onSubmit} onError={onError}>
+        <IressFormField
+          label="Label"
+          name="name"
+          readOnly
+          render={(controlledProps) => <IressInput {...controlledProps} />}
+          rules={{
+            required: 'This field is required',
+            minLength: { value: 5, message: 'Minimum 5 characters' },
+          }}
+        />
+        <IressButton type="submit">Submit</IressButton>
+      </IressForm>,
+    );
+
+    const submit = screen.getByRole('button', { name: 'Submit' });
+    await userEvent.click(submit);
+
+    // Should submit without errors since readOnly bypasses validation
+    expect(onSubmit).toHaveBeenCalledWith({ name: undefined });
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('renders supplementary content via renderSupplementary prop', async () => {
+    render(
+      <IressForm id="iress-form">
+        <IressFormField
+          label="Label"
+          name="name"
+          render={(controlledProps) => <IressInput {...controlledProps} />}
+          renderSupplementary={() => (
+            <div data-testid="supplementary-content">Character count: 0</div>
+          )}
+        />
+      </IressForm>,
+    );
+
+    const supplementary = await screen.findByTestId('supplementary-content');
+    expect(supplementary).toBeInTheDocument();
+    expect(supplementary).toHaveTextContent('Character count: 0');
+  });
+
+  it('provides field props and state to renderSupplementary', async () => {
+    const renderSupplementary = vi.fn(() => (
+      <div data-testid="supplementary">Supplementary</div>
+    ));
+
+    render(
+      <IressForm id="iress-form">
+        <IressFormField
+          label="Label"
+          name="name"
+          render={(controlledProps) => <IressInput {...controlledProps} />}
+          renderSupplementary={renderSupplementary}
+        />
+      </IressForm>,
+    );
+
+    await screen.findByTestId('supplementary');
+
+    expect(renderSupplementary).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'iress-form__name',
+        name: 'name',
+        value: undefined,
+        onChange: expect.any(Function) as never,
+        onBlur: expect.any(Function) as never,
+      }),
+      expect.objectContaining({
+        fieldState: expect.objectContaining({
+          isDirty: false,
+          isTouched: false,
+          invalid: false,
+        }) as never,
+        formState: expect.objectContaining({
+          defaultValues: expect.anything() as never,
+        }) as never,
+      }),
+    );
+  });
+
+  it('updates renderSupplementary when field value changes', async () => {
+    const renderSupplementary = vi.fn<
+      Exclude<
+        IressFormFieldProps<{
+          name: string;
+        }>['renderSupplementary'],
+        undefined
+      >
+    >((field) => (
+      <div data-testid="char-count">Characters: {field.value?.length ?? 0}</div>
+    ));
+
+    render(
+      <IressForm id="iress-form">
+        <IressFormField
+          label="Label"
+          name="name"
+          render={(controlledProps) => <IressInput {...controlledProps} />}
+          renderSupplementary={renderSupplementary}
+        />
+      </IressForm>,
+    );
+
+    const input = await screen.findByRole('textbox', { name: 'Label' });
+    const charCount = await screen.findByTestId('char-count');
+
+    expect(charCount).toHaveTextContent('Characters: 0');
+
+    await userEvent.type(input, 'test');
+
+    expect(charCount).toHaveTextContent('Characters: 4');
+    expect(renderSupplementary).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        value: 'test',
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it('renders both renderSupplementary and supplementary prop content', async () => {
+    render(
+      <IressForm id="iress-form">
+        <IressFormField
+          label="Label"
+          name="name"
+          render={(controlledProps) => <IressInput {...controlledProps} />}
+          renderSupplementary={() => (
+            <div data-testid="render-supplementary">Dynamic content</div>
+          )}
+          supplementary={
+            <div data-testid="static-supplementary">Static content</div>
+          }
+        />
+      </IressForm>,
+    );
+
+    const dynamicContent = await screen.findByTestId('render-supplementary');
+    const staticContent = await screen.findByTestId('static-supplementary');
+
+    expect(dynamicContent).toBeInTheDocument();
+    expect(staticContent).toBeInTheDocument();
+  });
+
+  it('provides field error state to renderSupplementary', async () => {
+    const renderSupplementary = vi.fn<
+      Exclude<
+        IressFormFieldProps<{
+          name: string;
+        }>['renderSupplementary'],
+        undefined
+      >
+    >((_field, state) => (
+      <div data-testid="error-indicator">
+        {state.fieldState?.error ? 'Error' : 'No error'}
+      </div>
+    ));
+
+    render(
+      <IressForm id="iress-form">
+        <IressFormField
+          label="Label"
+          name="name"
+          render={(controlledProps) => <IressInput {...controlledProps} />}
+          renderSupplementary={renderSupplementary}
+          rules={{ required: 'This field is required' }}
+        />
+        <IressButton type="submit">Submit</IressButton>
+      </IressForm>,
+    );
+
+    const errorIndicator = await screen.findByTestId('error-indicator');
+    expect(errorIndicator).toHaveTextContent('No error');
+
+    const submit = screen.getByRole('button', { name: 'Submit' });
+    await userEvent.click(submit);
+
+    // After submit with empty field, error should appear
+    const fieldError = await screen.findByText('This field is required');
+    expect(fieldError).toBeInTheDocument();
+    expect(errorIndicator).not.toBeInTheDocument();
   });
 
   describe('integration', () => {

--- a/packages/components/src/patterns/Form/FormField/FormField.tsx
+++ b/packages/components/src/patterns/Form/FormField/FormField.tsx
@@ -56,6 +56,16 @@ export interface IressFormFieldProps<
   ) => ReactNode;
 
   /**
+   * Render function to allow you to render supplementary content alongside the field, with access to the field props and state.
+   * This can be useful for rendering custom components that need to interact with the form state, such as character counters, password strength meters, or custom validation messages.
+   * (eg. `renderSupplementary={{ value } => <CharCount value={value} />}`)
+   */
+  renderSupplementary?: (
+    field: FormFieldRenderProps<T>,
+    state: FormFieldRenderState<T>,
+  ) => ReactNode;
+
+  /**
    * Validation rules, including: required, min, max, minLength, maxLength, pattern, validate
    * @see https://react-hook-form.com/api/useform/register)
    */
@@ -108,8 +118,10 @@ export const IressFormField = <T extends FieldValues>({
   defaultValue,
   name,
   render,
+  renderSupplementary,
   rules: withCustomRules,
   shouldUnregister,
+  supplementary,
   readOnly,
   ...fieldProps
 }: IressFormFieldProps<T>) => {
@@ -159,26 +171,33 @@ export const IressFormField = <T extends FieldValues>({
 
   const renderField = useFieldRenderProps<T>(field, fieldRef);
 
+  const controlProps = {
+    ...renderField,
+    id: `${form.id}__${name}`,
+  };
+
+  const controlState = {
+    formState,
+    fieldState,
+  };
+
   return (
     <IressField
       errorMessages={
         errorMessage && !readOnly ? [{ message: errorMessage }] : undefined
       }
+      htmlFor={`${form.id}__${name}`}
       readOnly={readOnly}
       required={!!rules?.required}
-      htmlFor={`${form.id}__${name}`}
+      supplementary={
+        <>
+          {renderSupplementary?.(controlProps, controlState)}
+          {supplementary}
+        </>
+      }
       {...fieldProps}
     >
-      {render(
-        {
-          ...renderField,
-          id: `${form.id}__${name}`,
-        },
-        {
-          formState,
-          fieldState,
-        },
-      )}
+      {render(controlProps, controlState)}
     </IressField>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1156,13 +1156,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/aix-ppc64@npm:0.27.0":
-  version: 0.27.0
-  resolution: "@esbuild/aix-ppc64@npm:0.27.0"
-  conditions: os=aix & cpu=ppc64
-  languageName: node
-  linkType: hard
-
 "@esbuild/aix-ppc64@npm:0.27.1":
   version: 0.27.1
   resolution: "@esbuild/aix-ppc64@npm:0.27.1"
@@ -1173,13 +1166,6 @@ __metadata:
 "@esbuild/android-arm64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/android-arm64@npm:0.25.12"
-  conditions: os=android & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/android-arm64@npm:0.27.0":
-  version: 0.27.0
-  resolution: "@esbuild/android-arm64@npm:0.27.0"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
@@ -1198,13 +1184,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/android-arm@npm:0.27.0":
-  version: 0.27.0
-  resolution: "@esbuild/android-arm@npm:0.27.0"
-  conditions: os=android & cpu=arm
-  languageName: node
-  linkType: hard
-
 "@esbuild/android-arm@npm:0.27.1":
   version: 0.27.1
   resolution: "@esbuild/android-arm@npm:0.27.1"
@@ -1215,13 +1194,6 @@ __metadata:
 "@esbuild/android-x64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/android-x64@npm:0.25.12"
-  conditions: os=android & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/android-x64@npm:0.27.0":
-  version: 0.27.0
-  resolution: "@esbuild/android-x64@npm:0.27.0"
   conditions: os=android & cpu=x64
   languageName: node
   linkType: hard
@@ -1240,13 +1212,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/darwin-arm64@npm:0.27.0":
-  version: 0.27.0
-  resolution: "@esbuild/darwin-arm64@npm:0.27.0"
-  conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
 "@esbuild/darwin-arm64@npm:0.27.1":
   version: 0.27.1
   resolution: "@esbuild/darwin-arm64@npm:0.27.1"
@@ -1257,13 +1222,6 @@ __metadata:
 "@esbuild/darwin-x64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/darwin-x64@npm:0.25.12"
-  conditions: os=darwin & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/darwin-x64@npm:0.27.0":
-  version: 0.27.0
-  resolution: "@esbuild/darwin-x64@npm:0.27.0"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -1282,13 +1240,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/freebsd-arm64@npm:0.27.0":
-  version: 0.27.0
-  resolution: "@esbuild/freebsd-arm64@npm:0.27.0"
-  conditions: os=freebsd & cpu=arm64
-  languageName: node
-  linkType: hard
-
 "@esbuild/freebsd-arm64@npm:0.27.1":
   version: 0.27.1
   resolution: "@esbuild/freebsd-arm64@npm:0.27.1"
@@ -1299,13 +1250,6 @@ __metadata:
 "@esbuild/freebsd-x64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/freebsd-x64@npm:0.25.12"
-  conditions: os=freebsd & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/freebsd-x64@npm:0.27.0":
-  version: 0.27.0
-  resolution: "@esbuild/freebsd-x64@npm:0.27.0"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
@@ -1324,13 +1268,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-arm64@npm:0.27.0":
-  version: 0.27.0
-  resolution: "@esbuild/linux-arm64@npm:0.27.0"
-  conditions: os=linux & cpu=arm64
-  languageName: node
-  linkType: hard
-
 "@esbuild/linux-arm64@npm:0.27.1":
   version: 0.27.1
   resolution: "@esbuild/linux-arm64@npm:0.27.1"
@@ -1341,13 +1278,6 @@ __metadata:
 "@esbuild/linux-arm@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/linux-arm@npm:0.25.12"
-  conditions: os=linux & cpu=arm
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-arm@npm:0.27.0":
-  version: 0.27.0
-  resolution: "@esbuild/linux-arm@npm:0.27.0"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
@@ -1366,13 +1296,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-ia32@npm:0.27.0":
-  version: 0.27.0
-  resolution: "@esbuild/linux-ia32@npm:0.27.0"
-  conditions: os=linux & cpu=ia32
-  languageName: node
-  linkType: hard
-
 "@esbuild/linux-ia32@npm:0.27.1":
   version: 0.27.1
   resolution: "@esbuild/linux-ia32@npm:0.27.1"
@@ -1383,13 +1306,6 @@ __metadata:
 "@esbuild/linux-loong64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/linux-loong64@npm:0.25.12"
-  conditions: os=linux & cpu=loong64
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-loong64@npm:0.27.0":
-  version: 0.27.0
-  resolution: "@esbuild/linux-loong64@npm:0.27.0"
   conditions: os=linux & cpu=loong64
   languageName: node
   linkType: hard
@@ -1408,13 +1324,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-mips64el@npm:0.27.0":
-  version: 0.27.0
-  resolution: "@esbuild/linux-mips64el@npm:0.27.0"
-  conditions: os=linux & cpu=mips64el
-  languageName: node
-  linkType: hard
-
 "@esbuild/linux-mips64el@npm:0.27.1":
   version: 0.27.1
   resolution: "@esbuild/linux-mips64el@npm:0.27.1"
@@ -1425,13 +1334,6 @@ __metadata:
 "@esbuild/linux-ppc64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/linux-ppc64@npm:0.25.12"
-  conditions: os=linux & cpu=ppc64
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-ppc64@npm:0.27.0":
-  version: 0.27.0
-  resolution: "@esbuild/linux-ppc64@npm:0.27.0"
   conditions: os=linux & cpu=ppc64
   languageName: node
   linkType: hard
@@ -1450,13 +1352,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-riscv64@npm:0.27.0":
-  version: 0.27.0
-  resolution: "@esbuild/linux-riscv64@npm:0.27.0"
-  conditions: os=linux & cpu=riscv64
-  languageName: node
-  linkType: hard
-
 "@esbuild/linux-riscv64@npm:0.27.1":
   version: 0.27.1
   resolution: "@esbuild/linux-riscv64@npm:0.27.1"
@@ -1467,13 +1362,6 @@ __metadata:
 "@esbuild/linux-s390x@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/linux-s390x@npm:0.25.12"
-  conditions: os=linux & cpu=s390x
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-s390x@npm:0.27.0":
-  version: 0.27.0
-  resolution: "@esbuild/linux-s390x@npm:0.27.0"
   conditions: os=linux & cpu=s390x
   languageName: node
   linkType: hard
@@ -1492,13 +1380,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-x64@npm:0.27.0":
-  version: 0.27.0
-  resolution: "@esbuild/linux-x64@npm:0.27.0"
-  conditions: os=linux & cpu=x64
-  languageName: node
-  linkType: hard
-
 "@esbuild/linux-x64@npm:0.27.1":
   version: 0.27.1
   resolution: "@esbuild/linux-x64@npm:0.27.1"
@@ -1509,13 +1390,6 @@ __metadata:
 "@esbuild/netbsd-arm64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/netbsd-arm64@npm:0.25.12"
-  conditions: os=netbsd & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/netbsd-arm64@npm:0.27.0":
-  version: 0.27.0
-  resolution: "@esbuild/netbsd-arm64@npm:0.27.0"
   conditions: os=netbsd & cpu=arm64
   languageName: node
   linkType: hard
@@ -1534,13 +1408,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/netbsd-x64@npm:0.27.0":
-  version: 0.27.0
-  resolution: "@esbuild/netbsd-x64@npm:0.27.0"
-  conditions: os=netbsd & cpu=x64
-  languageName: node
-  linkType: hard
-
 "@esbuild/netbsd-x64@npm:0.27.1":
   version: 0.27.1
   resolution: "@esbuild/netbsd-x64@npm:0.27.1"
@@ -1551,13 +1418,6 @@ __metadata:
 "@esbuild/openbsd-arm64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/openbsd-arm64@npm:0.25.12"
-  conditions: os=openbsd & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/openbsd-arm64@npm:0.27.0":
-  version: 0.27.0
-  resolution: "@esbuild/openbsd-arm64@npm:0.27.0"
   conditions: os=openbsd & cpu=arm64
   languageName: node
   linkType: hard
@@ -1576,13 +1436,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/openbsd-x64@npm:0.27.0":
-  version: 0.27.0
-  resolution: "@esbuild/openbsd-x64@npm:0.27.0"
-  conditions: os=openbsd & cpu=x64
-  languageName: node
-  linkType: hard
-
 "@esbuild/openbsd-x64@npm:0.27.1":
   version: 0.27.1
   resolution: "@esbuild/openbsd-x64@npm:0.27.1"
@@ -1593,13 +1446,6 @@ __metadata:
 "@esbuild/openharmony-arm64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/openharmony-arm64@npm:0.25.12"
-  conditions: os=openharmony & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/openharmony-arm64@npm:0.27.0":
-  version: 0.27.0
-  resolution: "@esbuild/openharmony-arm64@npm:0.27.0"
   conditions: os=openharmony & cpu=arm64
   languageName: node
   linkType: hard
@@ -1618,13 +1464,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/sunos-x64@npm:0.27.0":
-  version: 0.27.0
-  resolution: "@esbuild/sunos-x64@npm:0.27.0"
-  conditions: os=sunos & cpu=x64
-  languageName: node
-  linkType: hard
-
 "@esbuild/sunos-x64@npm:0.27.1":
   version: 0.27.1
   resolution: "@esbuild/sunos-x64@npm:0.27.1"
@@ -1635,13 +1474,6 @@ __metadata:
 "@esbuild/win32-arm64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/win32-arm64@npm:0.25.12"
-  conditions: os=win32 & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/win32-arm64@npm:0.27.0":
-  version: 0.27.0
-  resolution: "@esbuild/win32-arm64@npm:0.27.0"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -1660,13 +1492,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/win32-ia32@npm:0.27.0":
-  version: 0.27.0
-  resolution: "@esbuild/win32-ia32@npm:0.27.0"
-  conditions: os=win32 & cpu=ia32
-  languageName: node
-  linkType: hard
-
 "@esbuild/win32-ia32@npm:0.27.1":
   version: 0.27.1
   resolution: "@esbuild/win32-ia32@npm:0.27.1"
@@ -1677,13 +1502,6 @@ __metadata:
 "@esbuild/win32-x64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/win32-x64@npm:0.25.12"
-  conditions: os=win32 & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/win32-x64@npm:0.27.0":
-  version: 0.27.0
-  resolution: "@esbuild/win32-x64@npm:0.27.0"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -4408,16 +4226,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:*":
-  version: 19.2.2
-  resolution: "@types/react@npm:19.2.2"
-  dependencies:
-    csstype: "npm:^3.0.2"
-  checksum: 10c0/f830b1204aca4634ce3c6cb3477b5d3d066b80a4dd832a4ee0069acb504b6debd2416548a43a11c1407c12bc60e2dc6cf362934a18fe75fe06a69c0a98cba8ab
-  languageName: node
-  linkType: hard
-
-"@types/react@npm:^19.2.7":
+"@types/react@npm:*, @types/react@npm:^19.2.7":
   version: 19.2.7
   resolution: "@types/react@npm:19.2.7"
   dependencies:
@@ -6565,13 +6374,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"csstype@npm:^3.0.2":
-  version: 3.1.3
-  resolution: "csstype@npm:3.1.3"
-  checksum: 10c0/80c089d6f7e0c5b2bd83cf0539ab41474198579584fa10d86d0cafe0642202343cbc119e076a0b1aece191989477081415d66c9fefbf3c957fc2fc4b7009f248
-  languageName: node
-  linkType: hard
-
 "csstype@npm:^3.2.2":
   version: 3.2.3
   resolution: "csstype@npm:3.2.3"
@@ -7107,7 +6909,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"depd@npm:2.0.0, depd@npm:^2.0.0, depd@npm:~2.0.0":
+"depd@npm:^2.0.0, depd@npm:~2.0.0":
   version: 2.0.0
   resolution: "depd@npm:2.0.0"
   checksum: 10c0/58bd06ec20e19529b06f7ad07ddab60e504d9e0faca4bd23079fac2d279c3594334d736508dc350e06e510aba5e22e4594483b3a6562ce7c17dd797f4cc4ad2c
@@ -7517,96 +7319,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild@npm:^0.27.0":
-  version: 0.27.0
-  resolution: "esbuild@npm:0.27.0"
-  dependencies:
-    "@esbuild/aix-ppc64": "npm:0.27.0"
-    "@esbuild/android-arm": "npm:0.27.0"
-    "@esbuild/android-arm64": "npm:0.27.0"
-    "@esbuild/android-x64": "npm:0.27.0"
-    "@esbuild/darwin-arm64": "npm:0.27.0"
-    "@esbuild/darwin-x64": "npm:0.27.0"
-    "@esbuild/freebsd-arm64": "npm:0.27.0"
-    "@esbuild/freebsd-x64": "npm:0.27.0"
-    "@esbuild/linux-arm": "npm:0.27.0"
-    "@esbuild/linux-arm64": "npm:0.27.0"
-    "@esbuild/linux-ia32": "npm:0.27.0"
-    "@esbuild/linux-loong64": "npm:0.27.0"
-    "@esbuild/linux-mips64el": "npm:0.27.0"
-    "@esbuild/linux-ppc64": "npm:0.27.0"
-    "@esbuild/linux-riscv64": "npm:0.27.0"
-    "@esbuild/linux-s390x": "npm:0.27.0"
-    "@esbuild/linux-x64": "npm:0.27.0"
-    "@esbuild/netbsd-arm64": "npm:0.27.0"
-    "@esbuild/netbsd-x64": "npm:0.27.0"
-    "@esbuild/openbsd-arm64": "npm:0.27.0"
-    "@esbuild/openbsd-x64": "npm:0.27.0"
-    "@esbuild/openharmony-arm64": "npm:0.27.0"
-    "@esbuild/sunos-x64": "npm:0.27.0"
-    "@esbuild/win32-arm64": "npm:0.27.0"
-    "@esbuild/win32-ia32": "npm:0.27.0"
-    "@esbuild/win32-x64": "npm:0.27.0"
-  dependenciesMeta:
-    "@esbuild/aix-ppc64":
-      optional: true
-    "@esbuild/android-arm":
-      optional: true
-    "@esbuild/android-arm64":
-      optional: true
-    "@esbuild/android-x64":
-      optional: true
-    "@esbuild/darwin-arm64":
-      optional: true
-    "@esbuild/darwin-x64":
-      optional: true
-    "@esbuild/freebsd-arm64":
-      optional: true
-    "@esbuild/freebsd-x64":
-      optional: true
-    "@esbuild/linux-arm":
-      optional: true
-    "@esbuild/linux-arm64":
-      optional: true
-    "@esbuild/linux-ia32":
-      optional: true
-    "@esbuild/linux-loong64":
-      optional: true
-    "@esbuild/linux-mips64el":
-      optional: true
-    "@esbuild/linux-ppc64":
-      optional: true
-    "@esbuild/linux-riscv64":
-      optional: true
-    "@esbuild/linux-s390x":
-      optional: true
-    "@esbuild/linux-x64":
-      optional: true
-    "@esbuild/netbsd-arm64":
-      optional: true
-    "@esbuild/netbsd-x64":
-      optional: true
-    "@esbuild/openbsd-arm64":
-      optional: true
-    "@esbuild/openbsd-x64":
-      optional: true
-    "@esbuild/openharmony-arm64":
-      optional: true
-    "@esbuild/sunos-x64":
-      optional: true
-    "@esbuild/win32-arm64":
-      optional: true
-    "@esbuild/win32-ia32":
-      optional: true
-    "@esbuild/win32-x64":
-      optional: true
-  bin:
-    esbuild: bin/esbuild
-  checksum: 10c0/a3a1deec285337b7dfe25cbb9aa8765d27a0192b610a8477a39bf5bd907a6bdb75e98898b61fb4337114cfadb13163bd95977db14e241373115f548e235b40a2
-  languageName: node
-  linkType: hard
-
-"esbuild@npm:~0.27.0":
+"esbuild@npm:^0.27.0, esbuild@npm:~0.27.0":
   version: 0.27.1
   resolution: "esbuild@npm:0.27.1"
   dependencies:
@@ -8896,20 +8609,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-errors@npm:2.0.0, http-errors@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "http-errors@npm:2.0.0"
-  dependencies:
-    depd: "npm:2.0.0"
-    inherits: "npm:2.0.4"
-    setprototypeof: "npm:1.2.0"
-    statuses: "npm:2.0.1"
-    toidentifier: "npm:1.0.1"
-  checksum: 10c0/fc6f2715fe188d091274b5ffc8b3657bd85c63e969daa68ccb77afb05b071a4b62841acb7a21e417b5539014dff2ebf9550f0b14a9ff126f2734a7c1387f8e19
-  languageName: node
-  linkType: hard
-
-"http-errors@npm:~2.0.1":
+"http-errors@npm:^2.0.0, http-errors@npm:~2.0.1":
   version: 2.0.1
   resolution: "http-errors@npm:2.0.1"
   dependencies:
@@ -8967,7 +8667,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"iconv-lite@npm:0.7.0, iconv-lite@npm:^0.7.0, iconv-lite@npm:~0.7.0":
+"iconv-lite@npm:^0.7.0, iconv-lite@npm:~0.7.0":
   version: 0.7.0
   resolution: "iconv-lite@npm:0.7.0"
   dependencies:
@@ -9073,7 +8773,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inherits@npm:2.0.4, inherits@npm:^2.0.3, inherits@npm:~2.0.4":
+"inherits@npm:^2.0.3, inherits@npm:~2.0.4":
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 10c0/4e531f648b29039fb7426fb94075e6545faa1eb9fe83c29f0b6d9e7263aceb4289d2d4557db0d428188eeb449cc7c5e77b0a0b2c4e248ff2a65933a0dee49ef2
@@ -12985,19 +12685,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"raw-body@npm:^3.0.0":
-  version: 3.0.1
-  resolution: "raw-body@npm:3.0.1"
-  dependencies:
-    bytes: "npm:3.1.2"
-    http-errors: "npm:2.0.0"
-    iconv-lite: "npm:0.7.0"
-    unpipe: "npm:1.0.0"
-  checksum: 10c0/892f4fbd21ecab7e2fed0f045f7af9e16df7e8050879639d4e482784a2f4640aaaa33d916a0e98013f23acb82e09c2e3c57f84ab97104449f728d22f65a7d79a
-  languageName: node
-  linkType: hard
-
-"raw-body@npm:^3.0.1":
+"raw-body@npm:^3.0.0, raw-body@npm:^3.0.1":
   version: 3.0.2
   resolution: "raw-body@npm:3.0.2"
   dependencies:
@@ -13122,9 +12810,9 @@ __metadata:
   linkType: hard
 
 "react-is@npm:^19.2.1":
-  version: 19.2.3
-  resolution: "react-is@npm:19.2.3"
-  checksum: 10c0/2b54c422c21b8dbd68a435a1cce21ecd5b6f06f48659531f7d53dd7368365da5a67e946f352fb2010d11ca40658aa67bec90995f0f1ec5556c0f71dbffe54994
+  version: 19.2.1
+  resolution: "react-is@npm:19.2.1"
+  checksum: 10c0/0ebeaedb4ff615055cbcd758c7e22ba9644e21110adbd293dd1aada3591abf7399152a786cd120e324c10706d75e28c2130c27d1b9b5ae637aef4c52f4d17a91
   languageName: node
   linkType: hard
 
@@ -13730,7 +13418,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"setprototypeof@npm:1.2.0, setprototypeof@npm:~1.2.0":
+"setprototypeof@npm:~1.2.0":
   version: 1.2.0
   resolution: "setprototypeof@npm:1.2.0"
   checksum: 10c0/68733173026766fa0d9ecaeb07f0483f4c2dc70ca376b3b7c40b7cda909f94b0918f6c5ad5ce27a9160bdfb475efaa9d5e705a11d8eaae18f9835d20976028bc
@@ -14012,13 +13700,6 @@ __metadata:
   version: 0.0.2
   resolution: "stackback@npm:0.0.2"
   checksum: 10c0/89a1416668f950236dd5ac9f9a6b2588e1b9b62b1b6ad8dff1bfc5d1a15dbf0aafc9b52d2226d00c28dffff212da464eaeebfc6b7578b9d180cef3e3782c5983
-  languageName: node
-  linkType: hard
-
-"statuses@npm:2.0.1":
-  version: 2.0.1
-  resolution: "statuses@npm:2.0.1"
-  checksum: 10c0/34378b207a1620a24804ce8b5d230fea0c279f00b18a7209646d5d47e419d1cc23e7cbf33a25a1e51ac38973dc2ac2e1e9c647a8e481ef365f77668d72becfd0
   languageName: node
   linkType: hard
 
@@ -14583,7 +14264,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"toidentifier@npm:1.0.1, toidentifier@npm:~1.0.1":
+"toidentifier@npm:~1.0.1":
   version: 1.0.1
   resolution: "toidentifier@npm:1.0.1"
   checksum: 10c0/93937279934bd66cc3270016dd8d0afec14fb7c94a05c72dc57321f8bd1fa97e5bea6d1f7c89e728d077ca31ea125b78320a616a6c6cd0e6b9cb94cb864381c1
@@ -15068,7 +14749,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unpipe@npm:1.0.0, unpipe@npm:~1.0.0":
+"unpipe@npm:~1.0.0":
   version: 1.0.0
   resolution: "unpipe@npm:1.0.0"
   checksum: 10c0/193400255bd48968e5c5383730344fbb4fa114cdedfab26e329e50dd2d81b134244bb8a72c6ac1b10ab0281a58b363d06405632c9d49ca9dfd5e90cbd7d0f32c
@@ -15350,7 +15031,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:7.2.7":
+"vite@npm:7.2.7, vite@npm:^6.0.0 || ^7.0.0":
   version: 7.2.7
   resolution: "vite@npm:7.2.7"
   dependencies:
@@ -15402,61 +15083,6 @@ __metadata:
   bin:
     vite: bin/vite.js
   checksum: 10c0/0c502d9eb898d9c05061dbd8fd199f280b524bbb4c12ab5f88c7b12779947386684a269e4dd0aa424aa35bcd857f1aa44aadb9ea764702a5043af433052455b5
-  languageName: node
-  linkType: hard
-
-"vite@npm:^6.0.0 || ^7.0.0":
-  version: 7.2.4
-  resolution: "vite@npm:7.2.4"
-  dependencies:
-    esbuild: "npm:^0.25.0"
-    fdir: "npm:^6.5.0"
-    fsevents: "npm:~2.3.3"
-    picomatch: "npm:^4.0.3"
-    postcss: "npm:^8.5.6"
-    rollup: "npm:^4.43.0"
-    tinyglobby: "npm:^0.2.15"
-  peerDependencies:
-    "@types/node": ^20.19.0 || >=22.12.0
-    jiti: ">=1.21.0"
-    less: ^4.0.0
-    lightningcss: ^1.21.0
-    sass: ^1.70.0
-    sass-embedded: ^1.70.0
-    stylus: ">=0.54.8"
-    sugarss: ^5.0.0
-    terser: ^5.16.0
-    tsx: ^4.8.1
-    yaml: ^2.4.2
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  peerDependenciesMeta:
-    "@types/node":
-      optional: true
-    jiti:
-      optional: true
-    less:
-      optional: true
-    lightningcss:
-      optional: true
-    sass:
-      optional: true
-    sass-embedded:
-      optional: true
-    stylus:
-      optional: true
-    sugarss:
-      optional: true
-    terser:
-      optional: true
-    tsx:
-      optional: true
-    yaml:
-      optional: true
-  bin:
-    vite: bin/vite.js
-  checksum: 10c0/26aa0cad01d6e00f17c837b2a0587ab52f6bd0d0e64606b4220cfc58fa5fa76a4095ef3ea27c886bea542a346363912c4fad9f9462ef1e6757262fedfd5196b2
   languageName: node
   linkType: hard
 
@@ -15957,7 +15583,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:4.1.13":
+"zod@npm:4.1.13, zod@npm:^3.25 || ^4.0, zod@npm:^3.25.0 || ^4.0.0":
   version: 4.1.13
   resolution: "zod@npm:4.1.13"
   checksum: 10c0/d7e74e82dba81a91ffc3239cd85bc034abe193a28f7087a94ab258a3e48e9a7ca4141920cac979a0d781495b48fc547777394149f26be04c3dc642f58bbc3941
@@ -15968,20 +15594,6 @@ __metadata:
   version: 3.25.76
   resolution: "zod@npm:3.25.76"
   checksum: 10c0/5718ec35e3c40b600316c5b4c5e4976f7fee68151bc8f8d90ec18a469be9571f072e1bbaace10f1e85cf8892ea12d90821b200e980ab46916a6166a4260a983c
-  languageName: node
-  linkType: hard
-
-"zod@npm:^3.25 || ^4.0":
-  version: 4.2.1
-  resolution: "zod@npm:4.2.1"
-  checksum: 10c0/ecb5219bddf76a42d092a843fb98ad4cb78f1e1077082772b03ef032ee5cbc80790a4051836b962d26fb4af854323bc784d628bd1b8d9898149eba7af21c5560
-  languageName: node
-  linkType: hard
-
-"zod@npm:^3.25.0 || ^4.0.0":
-  version: 4.1.12
-  resolution: "zod@npm:4.1.12"
-  checksum: 10c0/b64c1feb19e99d77075261eaf613e0b2be4dfcd3551eff65ad8b4f2a079b61e379854d066f7d447491fcf193f45babd8095551a9d47973d30b46b6d8e2c46774
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Introduced `renderSupplementary` prop in `IressFormField` to allow rendering of supplementary content alongside the field with access to field props and state.
- Updated tests to cover various scenarios for the new `renderSupplementary` functionality, including dynamic character counts and error state indicators.
- Enhanced existing tests to ensure proper integration with the new prop and validate expected behaviors when the field value changes.