### PR TITLE
feat: add display names to various components for better debugging and readability

### DIFF
--- a/packages/components/src/components/Alert/Alert.tsx
+++ b/packages/components/src/components/Alert/Alert.tsx
@@ -186,3 +186,5 @@ export const IressAlert = ({
     </IressText>
   );
 };
+
+IressAlert.displayName = 'IressAlert';

--- a/packages/components/src/components/Autocomplete/components/AutocompleteInstructions.tsx
+++ b/packages/components/src/components/Autocomplete/components/AutocompleteInstructions.tsx
@@ -14,3 +14,5 @@ export const AutocompleteInstructions = ({
 
   return <IressPanel>{instructionText}</IressPanel>;
 };
+
+AutocompleteInstructions.displayName = 'AutocompleteInstructions';

--- a/packages/components/src/components/Badge/Badge.tsx
+++ b/packages/components/src/components/Badge/Badge.tsx
@@ -64,3 +64,5 @@ export const IressBadge = ({
     badge
   );
 };
+
+IressBadge.displayName = 'IressBadge';

--- a/packages/components/src/components/Button/Button.tsx
+++ b/packages/components/src/components/Button/Button.tsx
@@ -276,11 +276,15 @@ const Button = <
   );
 };
 
-export const IressButton = forwardRef(Button) as <
+export const IressButton = forwardRef(Button) as (<
   C extends ElementType | undefined = undefined,
   THref extends string | undefined = undefined,
 >(
   props: IressButtonProps<C, THref> & {
     ref?: ButtonRef<C, THref>;
   },
-) => ReactElement;
+) => ReactElement) & {
+  displayName: 'IressButton';
+};
+
+IressButton.displayName = 'IressButton';

--- a/packages/components/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/components/src/components/ButtonGroup/ButtonGroup.tsx
@@ -95,3 +95,5 @@ export const IressButtonGroup = <
     </ButtonGroupProvider>
   );
 };
+
+IressButtonGroup.displayName = 'IressButtonGroup';

--- a/packages/components/src/components/Card/Card.tsx
+++ b/packages/components/src/components/Card/Card.tsx
@@ -171,11 +171,18 @@ export const IressCard = <E extends ElementType = 'div'>({
     </StyledElement>
   );
 };
+
+IressCard.displayName = 'IressCard';
+
 export const IressButtonCard = (props: IressButtonCardProps) => {
   const { type = 'button', ...restProps } = props;
   return <IressCard element="button" type={type} {...restProps} />;
 };
 
+IressButtonCard.displayName = 'IressButtonCard';
+
 export const IressLinkCard = (props: IressLinkCardProps) => {
   return <IressCard element="a" {...props} />;
 };
+
+IressLinkCard.displayName = 'IressLinkCard';

--- a/packages/components/src/components/Checkbox/Checkbox.tsx
+++ b/packages/components/src/components/Checkbox/Checkbox.tsx
@@ -255,8 +255,12 @@ const Checkbox = <T = FormControlValue,>(
   );
 };
 
-export const IressCheckbox = forwardRef(Checkbox) as <T = FormControlValue>(
+export const IressCheckbox = forwardRef(Checkbox) as (<T = FormControlValue>(
   props: IressCheckboxProps<T> & {
     ref?: ForwardedRef<ReactHookFormCompatibleRef<HTMLInputElement>>;
   },
-) => ReactElement;
+) => ReactElement) & {
+  displayName: 'IressCheckbox';
+};
+
+IressCheckbox.displayName = 'IressCheckbox';

--- a/packages/components/src/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/packages/components/src/components/CheckboxGroup/CheckboxGroup.tsx
@@ -195,10 +195,14 @@ const CheckboxGroup = <T = FormControlValue,>(
   );
 };
 
-export const IressCheckboxGroup = forwardRef(CheckboxGroup) as <
+export const IressCheckboxGroup = forwardRef(CheckboxGroup) as (<
   T = FormControlValue,
 >(
   props: IressCheckboxGroupProps<T> & {
     ref?: ForwardedRef<CheckboxGroupRef<T>>;
   },
-) => ReactElement;
+) => ReactElement) & {
+  displayName: 'IressCheckboxGroup';
+};
+
+IressCheckboxGroup.displayName = 'IressCheckboxGroup';

--- a/packages/components/src/components/CheckboxMark/CheckboxMark.tsx
+++ b/packages/components/src/components/CheckboxMark/CheckboxMark.tsx
@@ -58,3 +58,5 @@ export const IressCheckboxMark = ({
     </svg>
   );
 };
+
+IressCheckboxMark.displayName = 'IressCheckboxMark';

--- a/packages/components/src/components/Col/Col.tsx
+++ b/packages/components/src/components/Col/Col.tsx
@@ -38,3 +38,5 @@ const Component = styled('div', col) as FC<IressColProps>;
 export const IressCol = ({ className, ...restProps }: IressColProps) => (
   <Component {...restProps} className={cx(className, GlobalCSSClass.Col)} />
 );
+
+IressCol.displayName = 'IressCol';

--- a/packages/components/src/components/Container/Container.tsx
+++ b/packages/components/src/components/Container/Container.tsx
@@ -28,3 +28,5 @@ export const IressContainer = ({
     className={cx(className, GlobalCSSClass.Container)}
   />
 );
+
+IressContainer.displayName = 'IressContainer';

--- a/packages/components/src/components/Divider/Divider.tsx
+++ b/packages/components/src/components/Divider/Divider.tsx
@@ -32,3 +32,5 @@ export const IressDivider = ({
     />
   );
 };
+
+IressDivider.displayName = 'IressDivider';

--- a/packages/components/src/components/Expander/Expander.tsx
+++ b/packages/components/src/components/Expander/Expander.tsx
@@ -111,3 +111,5 @@ export const IressExpander = ({
     </IressText>
   );
 };
+
+IressExpander.displayName = 'IressExpander';

--- a/packages/components/src/components/Field/Field.tsx
+++ b/packages/components/src/components/Field/Field.tsx
@@ -177,3 +177,5 @@ export const IressField = ({
     </styled.div>
   );
 };
+
+IressField.displayName = 'IressField';

--- a/packages/components/src/components/Field/FieldGroup/FieldGroup.tsx
+++ b/packages/components/src/components/Field/FieldGroup/FieldGroup.tsx
@@ -92,3 +92,5 @@ export const IressFieldGroup = ({
     </fieldset>
   );
 };
+
+IressFieldGroup.displayName = 'IressFieldGroup';

--- a/packages/components/src/components/Field/components/FieldFooter.tsx
+++ b/packages/components/src/components/Field/components/FieldFooter.tsx
@@ -95,3 +95,5 @@ export const FieldFooter = ({
     </styled.div>
   );
 };
+
+FieldFooter.displayName = 'FieldFooter';

--- a/packages/components/src/components/Field/components/FieldHint.tsx
+++ b/packages/components/src/components/Field/components/FieldHint.tsx
@@ -77,3 +77,5 @@ export const FieldHintIcon = ({ hint }: { hint: ReactNode }) => (
     />
   </IressTooltip>
 );
+
+FieldHint.displayName = 'FieldHint';

--- a/packages/components/src/components/Filter/Filter.tsx
+++ b/packages/components/src/components/Filter/Filter.tsx
@@ -348,10 +348,14 @@ const Filter = <TMultiple extends boolean = false>(
   );
 };
 
-export const IressFilter = forwardRef(Filter) as <
+export const IressFilter = forwardRef(Filter) as (<
   TMultiple extends boolean = false,
 >(
   props: IressFilterProps<TMultiple> & {
     ref?: ForwardedRef<FilterRef>;
   },
-) => ReactElement;
+) => ReactElement) & {
+  displayName: 'IressFilter';
+};
+
+IressFilter.displayName = 'IressFilter';

--- a/packages/components/src/components/Filter/components/FilterLabel.tsx
+++ b/packages/components/src/components/Filter/components/FilterLabel.tsx
@@ -22,3 +22,5 @@ export const FilterLabel = <TMultiple extends boolean = false>({
 
   return label;
 };
+
+FilterLabel.displayName = 'FilterLabel';

--- a/packages/components/src/components/Filter/components/FilterResultsDescriptor.tsx
+++ b/packages/components/src/components/Filter/components/FilterResultsDescriptor.tsx
@@ -44,3 +44,5 @@ export const FilterResultsDescriptor = ({
     </div>
   );
 };
+
+FilterResultsDescriptor.displayName = 'FilterResultsDescriptor';

--- a/packages/components/src/components/Hide/Hide.tsx
+++ b/packages/components/src/components/Hide/Hide.tsx
@@ -51,3 +51,5 @@ export const IressHide = ({
     </Div>
   );
 };
+
+IressHide.displayName = 'IressHide';

--- a/packages/components/src/components/Icon/Icon.tsx
+++ b/packages/components/src/components/Icon/Icon.tsx
@@ -80,3 +80,5 @@ export const IressIcon = ({
     />
   );
 };
+
+IressIcon.displayName = 'IressIcon';

--- a/packages/components/src/components/Image/Image.tsx
+++ b/packages/components/src/components/Image/Image.tsx
@@ -45,3 +45,5 @@ export const IressImage = ({
     />
   );
 };
+
+IressImage.displayName = 'IressImage';

--- a/packages/components/src/components/Inline/Inline.tsx
+++ b/packages/components/src/components/Inline/Inline.tsx
@@ -50,3 +50,5 @@ const Component = styled('div', inline) as FC<IressInlineProps>;
 export const IressInline = ({ className, ...restProps }: IressInlineProps) => (
   <Component {...restProps} className={cx(className, GlobalCSSClass.Inline)} />
 );
+
+IressInline.displayName = 'IressInline';

--- a/packages/components/src/components/Input/Input.tsx
+++ b/packages/components/src/components/Input/Input.tsx
@@ -274,9 +274,13 @@ const Input = <
   );
 };
 
-export const IressInput = forwardRef(Input) as <
+export const IressInput = forwardRef(Input) as (<
   T extends FormControlValue = string | number,
   TRows extends number | undefined = undefined,
 >(
   props: IressInputProps<T, TRows> & RefAttributes<InputRef<TRows> | null>,
-) => ReactElement;
+) => ReactElement) & {
+  displayName: 'IressInput';
+};
+
+IressInput.displayName = 'IressInput';

--- a/packages/components/src/components/Input/InputBase/InputBase.tsx
+++ b/packages/components/src/components/Input/InputBase/InputBase.tsx
@@ -93,10 +93,14 @@ const Input = <TRows extends number | undefined = undefined>(
  *
  * - **Ref Forwarding and Imperative Handle**: This component forwards a ref to the input or textarea element and provides a `focus` method via `useImperativeHandle`. This allows parent components to programmatically focus the input.
  */
-export const InputBase = forwardRef(Input) as <
+export const InputBase = forwardRef(Input) as (<
   TRows extends number | undefined = undefined,
 >(
   props: InputBaseProps<TRows> & {
     ref?: Ref<InputRef<TRows>>;
   },
-) => ReactElement;
+) => ReactElement) & {
+  displayName: 'InputBase';
+};
+
+InputBase.displayName = 'InputBase';

--- a/packages/components/src/components/InputCurrency/InputCurrency.tsx
+++ b/packages/components/src/components/InputCurrency/InputCurrency.tsx
@@ -1,7 +1,12 @@
 import { IressInput } from '@/components/Input';
 import { IressText } from '@/components/Text';
 import { type InputRef } from '@/components/Input/InputBase/InputBase';
-import { forwardRef, type ReactElement, type RefAttributes } from 'react';
+import {
+  type ForwardedRef,
+  forwardRef,
+  type ReactElement,
+  type RefAttributes,
+} from 'react';
 import { formatCurrency } from '@/helpers/formatting/formatCurrency';
 import { type IressInputProps } from '@/components/Input/Input';
 import { cx } from '@/styled-system/css';
@@ -10,7 +15,7 @@ import { type FormControlValue } from '@/types';
 
 export interface IressInputCurrencyProps<
   T extends FormControlValue = string | number,
-> extends IressInputProps<T, undefined> {
+> extends Omit<IressInputProps<T, undefined>, 'rows'> {
   /**
    * Set input content align to right.
    */
@@ -38,10 +43,12 @@ export interface IressInputCurrencyProps<
   withSymbol?: boolean;
 }
 
-export const IressInputCurrency = forwardRef<
-  InputRef<undefined>,
-  IressInputCurrencyProps
->((props, ref) => {
+const InputCurrency = <
+  T extends Exclude<FormControlValue, boolean> = string | number,
+>(
+  props: IressInputCurrencyProps<T>,
+  ref: ForwardedRef<InputRef>,
+) => {
   const {
     locale = 'en-AU',
     currencyCode = 'AUD',
@@ -54,7 +61,7 @@ export const IressInputCurrency = forwardRef<
   } = props;
 
   return (
-    <IressInput
+    <IressInput<T>
       className={cx(className, GlobalCSSClass.InputCurrency)}
       formatter={(value) =>
         formatCurrency({
@@ -73,6 +80,14 @@ export const IressInputCurrency = forwardRef<
       {...inputProps}
     />
   );
-}) as <T extends FormControlValue = string | number>(
-  props: IressInputCurrencyProps<T> & RefAttributes<InputRef<undefined> | null>,
-) => ReactElement;
+};
+
+export const IressInputCurrency = forwardRef(InputCurrency) as (<
+  T extends Exclude<FormControlValue, boolean> = string | number,
+>(
+  props: IressInputCurrencyProps<T> & RefAttributes<InputRef | null>,
+) => ReactElement) & {
+  displayName: 'IressInputCurrency';
+};
+
+IressInputCurrency.displayName = 'IressInputCurrency';

--- a/packages/components/src/components/Label/Label.tsx
+++ b/packages/components/src/components/Label/Label.tsx
@@ -24,3 +24,5 @@ export type IressLabelProps<THtmlFor extends string | undefined = undefined> =
 export const IressLabel = <THtmlFor extends string | undefined = undefined>(
   props: IressLabelProps<THtmlFor>,
 ) => <LabelBase {...props} element={props.htmlFor ? 'label' : 'strong'} />;
+
+IressLabel.displayName = 'IressLabel';

--- a/packages/components/src/components/Label/LabelBase/LabelBase.tsx
+++ b/packages/components/src/components/Label/LabelBase/LabelBase.tsx
@@ -99,3 +99,5 @@ export const LabelBase = <E extends 'label' | 'strong' | 'legend' = 'label'>({
     </Tag>
   );
 };
+
+LabelBase.displayName = 'LabelBase';

--- a/packages/components/src/components/Link/Link.tsx
+++ b/packages/components/src/components/Link/Link.tsx
@@ -170,11 +170,15 @@ const Link = <
   );
 };
 
-export const IressLink = forwardRef(Link) as <
+export const IressLink = forwardRef(Link) as (<
   C extends ElementType | undefined = undefined,
   THref extends string | undefined = undefined,
 >(
   props: IressLinkProps<C, THref> & {
     ref?: ButtonRef<C, THref>;
   },
-) => ReactElement;
+) => ReactElement) & {
+  displayName: 'IressLink';
+};
+
+IressLink.displayName = 'IressLink';

--- a/packages/components/src/components/Menu/Menu.tsx
+++ b/packages/components/src/components/Menu/Menu.tsx
@@ -316,3 +316,5 @@ export const IressMenu = <
     </Provider>
   );
 };
+
+IressMenu.displayName = 'IressMenu';

--- a/packages/components/src/components/Menu/MenuDivider/MenuDivider.tsx
+++ b/packages/components/src/components/Menu/MenuDivider/MenuDivider.tsx
@@ -24,3 +24,5 @@ export const IressMenuDivider = ({
     />
   );
 };
+
+IressMenuDivider.displayName = 'IressMenuDivider';

--- a/packages/components/src/components/Menu/MenuItem/MenuItem.tsx
+++ b/packages/components/src/components/Menu/MenuItem/MenuItem.tsx
@@ -451,11 +451,15 @@ const MenuItem = <
   );
 };
 
-export const IressMenuItem = forwardRef(MenuItem) as <
+export const IressMenuItem = forwardRef(MenuItem) as (<
   C extends ElementType | undefined = undefined,
   THref extends string | undefined = undefined,
 >(
   props: IressMenuItemProps<C, THref> & {
     ref?: ButtonRef<C, THref>;
   },
-) => ReactElement;
+) => ReactElement) & {
+  displayName: 'IressMenuItem';
+};
+
+IressMenuItem.displayName = 'IressMenuItem';

--- a/packages/components/src/components/Menu/MenuText/MenuText.tsx
+++ b/packages/components/src/components/Menu/MenuText/MenuText.tsx
@@ -96,6 +96,8 @@ export const IressMenuText = <E extends TextElements = 'div'>({
   );
 };
 
+IressMenuText.displayName = 'IressMenuText';
+
 export const IressMenuHeading = <E extends TextElements = 'h2'>({
   className,
   element = 'h2' as E,
@@ -109,3 +111,5 @@ export const IressMenuHeading = <E extends TextElements = 'h2'>({
     className={cx(className, GlobalCSSClass.MenuHeading)}
   />
 );
+
+IressMenuHeading.displayName = 'IressMenuHeading';

--- a/packages/components/src/components/Modal/Modal.tsx
+++ b/packages/components/src/components/Modal/Modal.tsx
@@ -316,3 +316,5 @@ export const IressModal = ({
     </FloatingPortal>
   );
 };
+
+IressModal.displayName = 'IressModal';

--- a/packages/components/src/components/Modal/ModalProvider.tsx
+++ b/packages/components/src/components/Modal/ModalProvider.tsx
@@ -49,3 +49,5 @@ export const IressModalProvider = ({
     </ModalContext.Provider>
   );
 };
+
+IressModalProvider.displayName = 'IressModalProvider';

--- a/packages/components/src/components/Panel/Panel.tsx
+++ b/packages/components/src/components/Panel/Panel.tsx
@@ -25,3 +25,5 @@ const Component = styled(IressText, panel) as FC<IressPanelProps>;
 export const IressPanel = ({ className, ...restProps }: IressPanelProps) => (
   <Component {...restProps} className={cx(className, GlobalCSSClass.Panel)} />
 );
+
+IressPanel.displayName = 'IressPanel';

--- a/packages/components/src/components/Placeholder/Placeholder.tsx
+++ b/packages/components/src/components/Placeholder/Placeholder.tsx
@@ -60,3 +60,5 @@ export const IressPlaceholder = ({
     </IressText>
   );
 };
+
+IressPlaceholder.displayName = 'IressPlaceholder';

--- a/packages/components/src/components/Popover/InputPopover/InputPopover.tsx
+++ b/packages/components/src/components/Popover/InputPopover/InputPopover.tsx
@@ -131,3 +131,5 @@ const InputPopover = (
 };
 
 export const IressInputPopover = forwardRef(InputPopover);
+
+InputPopover.displayName = 'IressInputPopover';

--- a/packages/components/src/components/Popover/InputPopover/InputPopoverActivator.tsx
+++ b/packages/components/src/components/Popover/InputPopover/InputPopoverActivator.tsx
@@ -99,3 +99,5 @@ export const InputPopoverActivator = ({
     </div>
   );
 };
+
+InputPopoverActivator.displayName = 'InputPopoverActivator';

--- a/packages/components/src/components/Popover/Popover.tsx
+++ b/packages/components/src/components/Popover/Popover.tsx
@@ -229,3 +229,5 @@ const Popover = (
 };
 
 export const IressPopover = forwardRef(Popover);
+
+IressPopover.displayName = 'IressPopover';

--- a/packages/components/src/components/Popover/components/NestedPopoverActivator.tsx
+++ b/packages/components/src/components/Popover/components/NestedPopoverActivator.tsx
@@ -16,3 +16,5 @@ export const NestedPopoverActivator = ({
     <FloatingList elementsRef={parentPopover.list}>{children}</FloatingList>
   );
 };
+
+NestedPopoverActivator.displayName = 'NestedPopoverActivator';

--- a/packages/components/src/components/Popover/components/PopoverActivator.tsx
+++ b/packages/components/src/components/Popover/components/PopoverActivator.tsx
@@ -147,3 +147,5 @@ export const PopoverActivator = ({
     </div>
   );
 };
+
+PopoverActivator.displayName = 'PopoverActivator';

--- a/packages/components/src/components/Popover/components/PopoverContent.tsx
+++ b/packages/components/src/components/Popover/components/PopoverContent.tsx
@@ -112,6 +112,8 @@ const PopoverContentInner = ({
   );
 };
 
+PopoverContentInner.displayName = 'PopoverContentInner';
+
 const PopoverContentContainer = ({
   container,
   ...restProps
@@ -135,6 +137,8 @@ const PopoverContentContainer = ({
   );
 };
 
+PopoverContentContainer.displayName = 'PopoverContentContainer';
+
 export const PopoverContent = (props: PopoverContentProps) => {
   const parentId = useFloatingParentNodeId();
 
@@ -149,3 +153,5 @@ export const PopoverContent = (props: PopoverContentProps) => {
 
   return <PopoverContentContainer {...props} />;
 };
+
+PopoverContent.displayName = 'PopoverContent';

--- a/packages/components/src/components/Progress/Progress.tsx
+++ b/packages/components/src/components/Progress/Progress.tsx
@@ -113,3 +113,5 @@ export const IressProgress = <TMin extends number | undefined = undefined>({
     />
   );
 };
+
+IressProgress.displayName = 'IressProgress';

--- a/packages/components/src/components/Provider/Provider.tsx
+++ b/packages/components/src/components/Provider/Provider.tsx
@@ -79,3 +79,5 @@ export const IressProvider = ({
     </IressModalProvider>
   );
 };
+
+IressProvider.displayName = 'IressProvider';

--- a/packages/components/src/components/Radio/Radio.tsx
+++ b/packages/components/src/components/Radio/Radio.tsx
@@ -197,6 +197,10 @@ const Radio = <T = FormControlValue,>(
   );
 };
 
-export const IressRadio = forwardRef(Radio) as <T = FormControlValue>(
+export const IressRadio = forwardRef(Radio) as (<T = FormControlValue>(
   props: IressRadioProps<T> & { ref?: Ref<HTMLInputElement> },
-) => ReactElement;
+) => ReactElement) & {
+  displayName: 'IressRadio';
+};
+
+IressRadio.displayName = 'IressRadio';

--- a/packages/components/src/components/RadioGroup/RadioGroup.tsx
+++ b/packages/components/src/components/RadioGroup/RadioGroup.tsx
@@ -202,6 +202,12 @@ const RadioGroup = <T = FormControlValue,>(
   );
 };
 
-export const IressRadioGroup = forwardRef(RadioGroup) as <T = FormControlValue>(
+export const IressRadioGroup = forwardRef(RadioGroup) as (<
+  T = FormControlValue,
+>(
   props: IressRadioGroupProps<T> & { ref?: Ref<RadioGroupRef> },
-) => ReactElement;
+) => ReactElement) & {
+  displayName: 'IressRadioGroup';
+};
+
+IressRadioGroup.displayName = 'IressRadioGroup';

--- a/packages/components/src/components/Readonly/Readonly.tsx
+++ b/packages/components/src/components/Readonly/Readonly.tsx
@@ -103,8 +103,12 @@ const Readonly = <T extends FormControlValue = string | number>(
   );
 };
 
-export const IressReadonly = forwardRef(Readonly) as <
+export const IressReadonly = forwardRef(Readonly) as (<
   T extends FormControlValue = string | number,
 >(
   props: IressReadonlyProps<T> & RefAttributes<HTMLInputElement | null>,
-) => ReactElement;
+) => ReactElement) & {
+  displayName: 'IressReadonly';
+};
+
+IressReadonly.displayName = 'IressReadonly';

--- a/packages/components/src/components/RichSelect/RichSelect.tsx
+++ b/packages/components/src/components/RichSelect/RichSelect.tsx
@@ -477,10 +477,14 @@ const RichSelect = <TMultiple extends boolean = false>(
   );
 };
 
-export const IressRichSelect = forwardRef(RichSelect) as <
+export const IressRichSelect = forwardRef(RichSelect) as (<
   TMultiple extends boolean = false,
 >(
   props: IressRichSelectProps<TMultiple> & {
     ref?: ForwardedRef<RichSelectRef>;
   },
-) => ReactElement;
+) => ReactElement) & {
+  displayName: 'IressRichSelect';
+};
+
+IressRichSelect.displayName = 'IressRichSelect';

--- a/packages/components/src/components/RichSelect/SelectBody/SelectBody.tsx
+++ b/packages/components/src/components/RichSelect/SelectBody/SelectBody.tsx
@@ -41,3 +41,5 @@ export const IressSelectBody = ({
     </IressText>
   );
 };
+
+IressSelectBody.displayName = 'IressSelectBody';

--- a/packages/components/src/components/RichSelect/SelectCreate/SelectCreate.tsx
+++ b/packages/components/src/components/RichSelect/SelectCreate/SelectCreate.tsx
@@ -87,3 +87,5 @@ export const IressSelectCreate = ({
     </IressMenu>
   );
 };
+
+IressSelectCreate.displayName = 'IressSelectCreate';

--- a/packages/components/src/components/RichSelect/SelectHeading/SelectHeading.tsx
+++ b/packages/components/src/components/RichSelect/SelectHeading/SelectHeading.tsx
@@ -97,3 +97,5 @@ export const IressSelectHeading = ({
     </IressInline>
   </IressMenuHeading>
 );
+
+IressSelectHeading.displayName = 'IressSelectHeading';

--- a/packages/components/src/components/RichSelect/SelectLabel/SelectLabel.tsx
+++ b/packages/components/src/components/RichSelect/SelectLabel/SelectLabel.tsx
@@ -58,3 +58,5 @@ export const IressSelectLabel = ({
     </button>
   );
 };
+
+IressSelectLabel.displayName = 'IressSelectLabel';

--- a/packages/components/src/components/RichSelect/SelectMenu/SelectMenu.tsx
+++ b/packages/components/src/components/RichSelect/SelectMenu/SelectMenu.tsx
@@ -191,6 +191,8 @@ export const IressSelectMenu = <TMultiple extends boolean = false>({
   );
 };
 
+IressSelectMenu.displayName = 'IressSelectMenu';
+
 const orderSelectedFirst = <TMultiple extends boolean = false>(
   items: LabelValueMeta[],
   selected?: IressSelectMenuProps<TMultiple>['selected'],

--- a/packages/components/src/components/RichSelect/SelectMenu/SelectMenuItem.tsx
+++ b/packages/components/src/components/RichSelect/SelectMenu/SelectMenuItem.tsx
@@ -60,3 +60,5 @@ export const IressSelectMenuItem = ({
     </IressMenuItem>
   );
 };
+
+IressSelectMenuItem.displayName = 'IressSelectMenuItem';

--- a/packages/components/src/components/RichSelect/SelectSearch/SelectSearch.tsx
+++ b/packages/components/src/components/RichSelect/SelectSearch/SelectSearch.tsx
@@ -52,3 +52,5 @@ export const IressSelectSearch = ({
     />
   );
 };
+
+IressSelectSearch.displayName = 'IressSelectSearch';

--- a/packages/components/src/components/RichSelect/SelectTags/SelectTags.tsx
+++ b/packages/components/src/components/RichSelect/SelectTags/SelectTags.tsx
@@ -253,3 +253,5 @@ export const IressSelectTags = ({
     </IressText>
   );
 };
+
+IressSelectTags.displayName = 'IressSelectTags';

--- a/packages/components/src/components/RichSelect/components/SelectActivator.tsx
+++ b/packages/components/src/components/RichSelect/components/SelectActivator.tsx
@@ -134,3 +134,5 @@ export const SelectActivator = <TMultiple extends boolean = false>({
     />
   );
 };
+
+SelectActivator.displayName = 'SelectActivator';

--- a/packages/components/src/components/RichSelect/components/SelectHiddenInput.tsx
+++ b/packages/components/src/components/RichSelect/components/SelectHiddenInput.tsx
@@ -66,10 +66,14 @@ const Component = <TMultiple extends boolean = false>(
   );
 };
 
-export const SelectHiddenInput = forwardRef(Component) as <
+export const SelectHiddenInput = forwardRef(Component) as (<
   TMultiple extends boolean,
 >(
   props: SelectHiddenInputProps<TMultiple> & {
     ref?: ForwardedRef<HTMLInputElement>;
   },
-) => ReactElement;
+) => ReactElement) & {
+  displayName: 'SelectHiddenInput';
+};
+
+SelectHiddenInput.displayName = 'SelectHiddenInput';

--- a/packages/components/src/components/RichSelect/components/SelectOptions.tsx
+++ b/packages/components/src/components/RichSelect/components/SelectOptions.tsx
@@ -100,6 +100,8 @@ const SelectAsyncResults = <TMultiple extends boolean = false>({
   );
 };
 
+SelectAsyncResults.displayName = 'SelectAsyncResults';
+
 const SelectAsyncError = ({ error }: Pick<SelectOptionsProps, 'error'>) => {
   if (!error) return null;
 
@@ -116,6 +118,8 @@ const SelectAsyncError = ({ error }: Pick<SelectOptionsProps, 'error'>) => {
     </IressAlert>
   );
 };
+
+SelectAsyncError.displayName = 'SelectAsyncError';
 
 const SelectAsyncOptions = <TMultiple extends boolean = false>({
   autoHighlight,
@@ -227,6 +231,8 @@ const SelectAsyncOptions = <TMultiple extends boolean = false>({
   );
 };
 
+SelectAsyncOptions.displayName = 'SelectAsyncOptions';
+
 export const SelectOptions = <TMultiple extends boolean = false>({
   autoHighlight,
   debouncedQuery,
@@ -335,3 +341,5 @@ export const SelectOptions = <TMultiple extends boolean = false>({
     />
   );
 };
+
+SelectOptions.displayName = 'SelectOptions';

--- a/packages/components/src/components/Row/Row.tsx
+++ b/packages/components/src/components/Row/Row.tsx
@@ -46,3 +46,5 @@ const Component = styled('div', row) as FC<IressRowProps>;
 export const IressRow = ({ className, ...restProps }: IressRowProps) => (
   <Component {...restProps} className={cx(className, GlobalCSSClass.Row)} />
 );
+
+IressRow.displayName = 'IressRow';

--- a/packages/components/src/components/Select/Select.tsx
+++ b/packages/components/src/components/Select/Select.tsx
@@ -192,11 +192,15 @@ const Select = <
   );
 };
 
-export const IressSelect = forwardRef(Select) as <
+export const IressSelect = forwardRef(Select) as (<
   T extends FormControlValue = FormControlValue,
   TReadonly extends boolean | undefined = undefined,
 >(
   props: IressSelectProps<T, TReadonly> & {
     ref?: ForwardedRef<HTMLElementTagNameMap[SelectElement<TReadonly>]>;
   },
-) => ReactElement;
+) => ReactElement) & {
+  displayName: 'IressSelect';
+};
+
+IressSelect.displayName = 'IressSelect';

--- a/packages/components/src/components/Select/components/SelectControl.tsx
+++ b/packages/components/src/components/Select/components/SelectControl.tsx
@@ -66,6 +66,10 @@ const Component = <T = FormControlValue,>(
   );
 };
 
-export const SelectControl = forwardRef(Component) as <T = FormControlValue>(
+export const SelectControl = forwardRef(Component) as (<T = FormControlValue>(
   props: SelectControlProps<T> & { ref?: Ref<HTMLSelectElement> },
-) => ReactElement;
+) => ReactElement) & {
+  displayName: 'SelectControl';
+};
+
+SelectControl.displayName = 'SelectControl';

--- a/packages/components/src/components/Select/components/SelectReadonly.tsx
+++ b/packages/components/src/components/Select/components/SelectReadonly.tsx
@@ -61,8 +61,12 @@ const Component = <T extends FormControlValue = FormControlValue>(
   );
 };
 
-export const SelectReadonly = forwardRef(Component) as <
+export const SelectReadonly = forwardRef(Component) as (<
   T extends FormControlValue = FormControlValue,
 >(
   props: SelectReadonlyProps<T> & { ref?: Ref<HTMLInputElement> },
-) => ReactElement;
+) => ReactElement) & {
+  displayName: 'SelectReadonly';
+};
+
+SelectReadonly.displayName = 'SelectReadonly';

--- a/packages/components/src/components/Skeleton/Skeleton.tsx
+++ b/packages/components/src/components/Skeleton/Skeleton.tsx
@@ -64,3 +64,5 @@ export const IressSkeleton = <TMode extends SkeletonMode = 'text'>({
     </IressText>
   );
 };
+
+IressSkeleton.displayName = 'IressSkeleton';

--- a/packages/components/src/components/SkipLink/SkipLink.tsx
+++ b/packages/components/src/components/SkipLink/SkipLink.tsx
@@ -49,11 +49,15 @@ const SkipLink = <
   </IressButton>
 );
 
-export const IressSkipLink = forwardRef(SkipLink) as <
+export const IressSkipLink = forwardRef(SkipLink) as (<
   C extends ElementType | undefined = undefined,
   THref extends string | undefined = undefined,
 >(
   props: IressSkipLinkProps<C, THref> & {
     ref?: ButtonRef<C, THref>;
   },
-) => ReactElement;
+) => ReactElement) & {
+  displayName: 'IressSkipLink';
+};
+
+IressSkipLink.displayName = 'IressSkipLink';

--- a/packages/components/src/components/Slideout/Slideout.tsx
+++ b/packages/components/src/components/Slideout/Slideout.tsx
@@ -331,3 +331,5 @@ export const IressSlideout = ({
     </FloatingPortal>
   );
 };
+
+IressSlideout.displayName = 'IressSlideout';

--- a/packages/components/src/components/Slideout/SlideoutProvider.tsx
+++ b/packages/components/src/components/Slideout/SlideoutProvider.tsx
@@ -60,3 +60,5 @@ export const IressSlideoutProvider = ({
     </SlideoutContext.Provider>
   );
 };
+
+IressSlideoutProvider.displayName = 'IressSlideoutProvider';

--- a/packages/components/src/components/Slideout/components/SlideoutInner.tsx
+++ b/packages/components/src/components/Slideout/components/SlideoutInner.tsx
@@ -86,3 +86,5 @@ export const SlideoutInner = ({
     </styled.div>
   );
 };
+
+SlideoutInner.displayName = 'SlideoutInner';

--- a/packages/components/src/components/Slider/Slider.tsx
+++ b/packages/components/src/components/Slider/Slider.tsx
@@ -234,3 +234,5 @@ const Slider = (
 };
 
 export const IressSlider = forwardRef(Slider);
+
+IressSlider.displayName = 'IressSlider';

--- a/packages/components/src/components/Slider/components/SliderTicks.tsx
+++ b/packages/components/src/components/Slider/components/SliderTicks.tsx
@@ -124,6 +124,8 @@ const TickMark = ({
   );
 };
 
+TickMark.displayName = 'TickMark';
+
 export const SliderTicks = ({
   max = 10,
   min = 0,
@@ -148,3 +150,5 @@ export const SliderTicks = ({
     </datalist>
   );
 };
+
+SliderTicks.displayName = 'SliderTicks';

--- a/packages/components/src/components/Spinner/Spinner.tsx
+++ b/packages/components/src/components/Spinner/Spinner.tsx
@@ -25,3 +25,5 @@ export const IressSpinner = ({
     />
   );
 };
+
+IressSpinner.displayName = 'IressSpinner';

--- a/packages/components/src/components/Stack/Stack.tsx
+++ b/packages/components/src/components/Stack/Stack.tsx
@@ -55,3 +55,5 @@ export const IressStack = <
     />
   );
 };
+
+IressStack.displayName = 'IressStack';

--- a/packages/components/src/components/TabSet/Tab/Tab.tsx
+++ b/packages/components/src/components/TabSet/Tab/Tab.tsx
@@ -143,6 +143,8 @@ const TabInsideTabSet = ({
   />
 );
 
+TabInsideTabSet.displayName = 'TabInsideTabSet';
+
 const Tab = <THref extends string | undefined = undefined>(
   {
     active,
@@ -291,10 +293,14 @@ const Tab = <THref extends string | undefined = undefined>(
   );
 };
 
-export const IressTab = forwardRef(Tab) as <
+export const IressTab = forwardRef(Tab) as (<
   THref extends string | undefined = undefined,
 >(
   props: IressTabProps<THref> & {
     ref?: Ref<HTMLElementTagNameMap[ButtonElement<undefined, THref>]>;
   },
-) => ReactElement;
+) => ReactElement) & {
+  displayName: 'IressTab';
+};
+
+IressTab.displayName = 'IressTab';

--- a/packages/components/src/components/TabSet/TabSet.tsx
+++ b/packages/components/src/components/TabSet/TabSet.tsx
@@ -169,3 +169,5 @@ export const IressTabSet = ({
     </TabSetProvider>
   );
 };
+
+IressTabSet.displayName = 'IressTabSet';

--- a/packages/components/src/components/TabSet/TabSetProvider.tsx
+++ b/packages/components/src/components/TabSet/TabSetProvider.tsx
@@ -160,3 +160,5 @@ export const TabSetProvider = ({
     <TabSetContext.Provider value={context}>{children}</TabSetContext.Provider>
   );
 };
+
+TabSetProvider.displayName = 'TabSetProvider';

--- a/packages/components/src/components/Table/Table.tsx
+++ b/packages/components/src/components/Table/Table.tsx
@@ -168,3 +168,5 @@ export const IressTable = <TRow extends object = never, TVal = never>({
     </div>
   );
 };
+
+IressTable.displayName = 'IressTable';

--- a/packages/components/src/components/Table/TableBody/TableBody.tsx
+++ b/packages/components/src/components/Table/TableBody/TableBody.tsx
@@ -94,6 +94,8 @@ const TableBodyHeader = ({
   );
 };
 
+TableBodyHeader.displayName = 'TableBodyHeader';
+
 const TableBodyChildren = ({
   children,
   setControlViaRef,
@@ -115,6 +117,8 @@ const TableBodyChildren = ({
     </tr>
   );
 };
+
+TableBodyChildren.displayName = 'TableBodyChildren';
 
 export const IressTableBody = <TRow extends object = never, TVal = never>({
   caption,
@@ -198,3 +202,5 @@ export const IressTableBody = <TRow extends object = never, TVal = never>({
     </TableProvider>
   );
 };
+
+IressTableBody.displayName = 'IressTableBody';

--- a/packages/components/src/components/Table/TableFormattedValue/TableFormattedValue.tsx
+++ b/packages/components/src/components/Table/TableFormattedValue/TableFormattedValue.tsx
@@ -71,3 +71,5 @@ export const IressTableFormattedValue = <TRow extends object, TVal = unknown>({
   if (format === 'percent') return formatPercentage(value as never);
   return value;
 };
+
+IressTableFormattedValue.displayName = 'IressTableFormattedValue';

--- a/packages/components/src/components/Table/TableProvider.tsx
+++ b/packages/components/src/components/Table/TableProvider.tsx
@@ -71,3 +71,5 @@ export const TableProvider = <TRow extends object, TVal = unknown>({
   const { Provider } = getTableContext<TRow, TVal>();
   return <Provider value={context}>{children}</Provider>;
 };
+
+TableProvider.displayName = 'TableProvider';

--- a/packages/components/src/components/Table/components/TableBodyCell.tsx
+++ b/packages/components/src/components/Table/components/TableBodyCell.tsx
@@ -49,3 +49,5 @@ export const TableBodyCell = <TRow extends object = never>({
     </Element>
   );
 };
+
+TableBodyCell.displayName = 'TableBodyCell';

--- a/packages/components/src/components/Table/components/TableEmpty.tsx
+++ b/packages/components/src/components/Table/components/TableEmpty.tsx
@@ -16,3 +16,5 @@ export const TableEmpty = ({ children }: PropsWithChildren) => {
     </tr>
   );
 };
+
+TableEmpty.displayName = 'TableEmpty';

--- a/packages/components/src/components/Table/components/TableHeader.tsx
+++ b/packages/components/src/components/Table/components/TableHeader.tsx
@@ -56,3 +56,5 @@ export const TableHeader = ({
     </tr>
   ));
 };
+
+TableHeader.displayName = 'TableHeader';

--- a/packages/components/src/components/Table/components/TableHeaderCell.tsx
+++ b/packages/components/src/components/Table/components/TableHeaderCell.tsx
@@ -50,3 +50,5 @@ export const TableHeaderCell = ({
     </th>
   );
 };
+
+TableHeaderCell.displayName = 'TableHeaderCell';

--- a/packages/components/src/components/Table/components/TableRows.tsx
+++ b/packages/components/src/components/Table/components/TableRows.tsx
@@ -65,3 +65,5 @@ export const TableRows = <TRow extends object = never>({
     </styled.tr>
   ));
 };
+
+TableRows.displayName = 'TableRows';

--- a/packages/components/src/components/Table/components/TableSortButton.tsx
+++ b/packages/components/src/components/Table/components/TableSortButton.tsx
@@ -35,3 +35,5 @@ export const TableSortButton = ({
     </button>
   );
 };
+
+TableSortButton.displayName = 'TableSortButton';

--- a/packages/components/src/components/Tag/Tag.tsx
+++ b/packages/components/src/components/Tag/Tag.tsx
@@ -78,3 +78,5 @@ export const IressTag = ({
     </IressText>
   );
 };
+
+IressTag.displayName = 'IressTag';

--- a/packages/components/src/components/Tag/TagInput/TagInput.tsx
+++ b/packages/components/src/components/Tag/TagInput/TagInput.tsx
@@ -121,6 +121,8 @@ const Tags = ({
   );
 };
 
+Tags.displayName = 'Tags';
+
 export const IressTagInput = forwardRef(
   (
     {

--- a/packages/components/src/components/Text/Text.tsx
+++ b/packages/components/src/components/Text/Text.tsx
@@ -49,3 +49,5 @@ export const IressText = <E extends TextElements = 'div'>({
     />
   );
 };
+
+IressText.displayName = 'IressText';

--- a/packages/components/src/components/Toaster/Toaster.tsx
+++ b/packages/components/src/components/Toaster/Toaster.tsx
@@ -119,3 +119,5 @@ export const Toaster = ({
     </>
   );
 };
+
+Toaster.displayName = 'Toaster';

--- a/packages/components/src/components/Toaster/ToasterProvider.tsx
+++ b/packages/components/src/components/Toaster/ToasterProvider.tsx
@@ -94,3 +94,5 @@ export const IressToasterProvider = ({
     </ToasterContext.Provider>
   );
 };
+
+IressToasterProvider.displayName = 'IressToasterProvider';

--- a/packages/components/src/components/Toaster/components/Toast/ToastAnimated.tsx
+++ b/packages/components/src/components/Toaster/components/Toast/ToastAnimated.tsx
@@ -86,3 +86,5 @@ export const ToastAnimated = ({
     />
   );
 };
+
+ToastAnimated.displayName = 'ToastAnimated';

--- a/packages/components/src/components/Toggle/Toggle.tsx
+++ b/packages/components/src/components/Toggle/Toggle.tsx
@@ -74,6 +74,7 @@ const ToggleLabel = ({
     </span>
   );
 };
+ToggleLabel.displayName = 'ToggleLabel';
 
 export const IressToggle = ({
   checked: checkedProp,
@@ -158,3 +159,4 @@ export const IressToggle = ({
     </styled.div>
   );
 };
+IressToggle.displayName = 'IressToggle';

--- a/packages/components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/components/src/components/Tooltip/Tooltip.tsx
@@ -135,3 +135,4 @@ export const IressTooltip = ({
     </styled.div>
   );
 };
+IressTooltip.displayName = 'IressTooltip';

--- a/packages/components/src/components/ValidationMessage/ValidationLink/ValidationLink.tsx
+++ b/packages/components/src/components/ValidationMessage/ValidationLink/ValidationLink.tsx
@@ -35,3 +35,4 @@ export const IressValidationLink = ({
     linkToTarget={linkToTarget}
   />
 );
+IressValidationLink.displayName = 'IressValidationLink';

--- a/packages/components/src/components/ValidationMessage/ValidationMessage.tsx
+++ b/packages/components/src/components/ValidationMessage/ValidationMessage.tsx
@@ -60,6 +60,7 @@ const ValidationPrefix = ({
     status === 'danger' ? 'Error' : capitalizeFirstLetter(status);
   return `${statusPrefix}: `;
 };
+ValidationPrefix.displayName = 'ValidationPrefix';
 
 export const IressValidationMessage = <
   TLinkToTarget extends string | undefined = undefined,
@@ -109,3 +110,4 @@ export const IressValidationMessage = <
     <styled.div display="inline">{children}</styled.div>
   </IressText>
 );
+IressValidationMessage.displayName = 'IressValidationMessage';

--- a/packages/components/src/components/ValidationMessage/ValidationSummary/ValidationSummary.tsx
+++ b/packages/components/src/components/ValidationMessage/ValidationSummary/ValidationSummary.tsx
@@ -107,3 +107,4 @@ export const IressValidationSummary = ({
     </styled.ul>
   );
 };
+IressValidationSummary.displayName = 'IressValidationSummary';

--- a/packages/components/src/patterns/Form/Form.tsx
+++ b/packages/components/src/patterns/Form/Form.tsx
@@ -25,6 +25,9 @@ const Form = <T extends FieldValues, TContext = object>(
 
 Form.displayName = 'IressForm';
 
-export const IressForm = forwardRef(Form) as <T extends FieldValues>(
+export const IressForm = forwardRef(Form) as (<T extends FieldValues>(
   props: IressFormProps<T> & { ref?: Ref<FormRef<T>> },
-) => React.ReactElement;
+) => React.ReactElement) & {
+  displayName: 'IressForm';
+};
+IressForm.displayName = 'IressForm';

--- a/packages/components/src/patterns/Form/FormContext.tsx
+++ b/packages/components/src/patterns/Form/FormContext.tsx
@@ -34,3 +34,4 @@ export interface FormContextValue {
 export const FormContext = createContext<FormContextValue | undefined>(
   undefined,
 );
+FormContext.displayName = 'FormContext';

--- a/packages/components/src/patterns/Form/FormField/FormField.tsx
+++ b/packages/components/src/patterns/Form/FormField/FormField.tsx
@@ -204,3 +204,4 @@ export const IressFormField = <T extends FieldValues>({
     </IressField>
   );
 };
+IressFormField.displayName = 'IressFormField';

--- a/packages/components/src/patterns/Form/FormField/FormFieldset.tsx
+++ b/packages/components/src/patterns/Form/FormField/FormFieldset.tsx
@@ -128,3 +128,4 @@ export const IressFormFieldset = <TFieldValues extends FieldValues>({
     </IressFieldGroup>
   );
 };
+IressFormFieldset.displayName = 'IressFormFieldset';

--- a/packages/components/src/patterns/Form/FormValidationSummary/FormValidationSummary.tsx
+++ b/packages/components/src/patterns/Form/FormValidationSummary/FormValidationSummary.tsx
@@ -133,3 +133,4 @@ export const IressFormValidationSummary = ({
     </FocusableAlert>
   );
 };
+IressFormValidationSummary.displayName = 'IressFormValidationSummary';

--- a/packages/components/src/patterns/Form/HookForm/HookForm.tsx
+++ b/packages/components/src/patterns/Form/HookForm/HookForm.tsx
@@ -359,11 +359,14 @@ const HookForm = <T extends FieldValues, TContext = object>(
 
 HookForm.displayName = 'IressHookForm';
 
-export const IressHookForm = forwardRef(HookForm) as <
+export const IressHookForm = forwardRef(HookForm) as (<
   T extends FieldValues,
   TContext = object,
 >(
   props: IressHookFormProps<T, TContext> & {
     ref?: Ref<FormRef<T>>;
   },
-) => ReactElement;
+) => ReactElement) & {
+  displayName: 'IressHookForm';
+};
+IressHookForm.displayName = 'IressHookForm';

--- a/packages/components/src/patterns/Form/components/LongForm.tsx
+++ b/packages/components/src/patterns/Form/components/LongForm.tsx
@@ -154,11 +154,14 @@ const LongFormPattern = <T extends FieldValues, TContext = object>(
   );
 };
 
-export const LongForm = forwardRef(LongFormPattern) as <
+export const LongForm = forwardRef(LongFormPattern) as (<
   T extends FieldValues,
   TContext = object,
 >(
   props: LongFormProps<T, TContext> & {
     ref?: Ref<FormRef<T>>;
   },
-) => ReactElement;
+) => ReactElement) & {
+  displayName: 'LongForm';
+};
+LongForm.displayName = 'LongForm';

--- a/packages/components/src/patterns/Form/components/ShortForm.tsx
+++ b/packages/components/src/patterns/Form/components/ShortForm.tsx
@@ -117,11 +117,14 @@ const ShortFormPattern = <T extends FieldValues, TContext = object>(
   );
 };
 
-export const ShortForm = forwardRef(ShortFormPattern) as <
+export const ShortForm = forwardRef(ShortFormPattern) as (<
   T extends FieldValues,
   TContext = object,
 >(
   props: ShortFormProps<T, TContext> & {
     ref?: Ref<FormRef<T>>;
   },
-) => ReactElement;
+) => ReactElement) & {
+  displayName: 'ShortForm';
+};
+ShortForm.displayName = 'ShortForm';

--- a/packages/components/src/patterns/Loading/Loading.tsx
+++ b/packages/components/src/patterns/Loading/Loading.tsx
@@ -79,6 +79,8 @@ export const IressLoading = ({ pattern, ...restProps }: IressLoadingProps) => {
   return <DefaultLoading {...(restProps as DefaultLoadingProps)} />;
 };
 
+IressLoading.displayName = 'IressLoading';
+
 /**
  * This hook is used to smooth the loading experience by delaying the loading indicator being removed after the loading of an element finishes.
  *

--- a/packages/components/src/patterns/Loading/LoadingSuspense.tsx
+++ b/packages/components/src/patterns/Loading/LoadingSuspense.tsx
@@ -189,6 +189,7 @@ export const IressLoadingSuspense = ({
     </>
   );
 };
+IressLoadingSuspense.displayName = 'IressLoadingSuspense';
 
 /**
  * A polyfill for the `use` hook in React 19. It allows you to suspend a component until the resource (Promise) is resolved.

--- a/packages/components/src/patterns/Loading/components/ComponentLoading.tsx
+++ b/packages/components/src/patterns/Loading/components/ComponentLoading.tsx
@@ -142,3 +142,4 @@ export const ComponentLoading = ({
     </styled.div>
   );
 };
+ComponentLoading.displayName = 'ComponentLoading';

--- a/packages/components/src/patterns/Loading/components/DefaultLoading.tsx
+++ b/packages/components/src/patterns/Loading/components/DefaultLoading.tsx
@@ -69,3 +69,5 @@ export const DefaultLoading = ({
     </styled.div>
   );
 };
+
+DefaultLoading.displayName = 'DefaultLoading';

--- a/packages/components/src/patterns/Loading/components/LongLoading.tsx
+++ b/packages/components/src/patterns/Loading/components/LongLoading.tsx
@@ -219,3 +219,5 @@ export const LongLoading = ({
     </styled.div>
   );
 };
+
+LongLoading.displayName = 'LongLoading';

--- a/packages/components/src/patterns/Loading/components/PageLoading.tsx
+++ b/packages/components/src/patterns/Loading/components/PageLoading.tsx
@@ -196,3 +196,4 @@ export const PageLoading = ({
     </styled.div>
   );
 };
+PageLoading.displayName = 'PageLoading';

--- a/packages/components/src/patterns/Loading/components/StartUpLoading.tsx
+++ b/packages/components/src/patterns/Loading/components/StartUpLoading.tsx
@@ -222,3 +222,4 @@ export const StartUpLoading = ({
     </div>
   );
 };
+StartUpLoading.displayName = 'StartUpLoading';

--- a/packages/components/src/patterns/Loading/components/ValidateLoading.tsx
+++ b/packages/components/src/patterns/Loading/components/ValidateLoading.tsx
@@ -89,3 +89,4 @@ export const ValidateLoading = ({
     </styled.div>
   );
 };
+ValidateLoading.displayName = 'ValidateLoading';

--- a/packages/components/src/patterns/Shadow/Shadow.tsx
+++ b/packages/components/src/patterns/Shadow/Shadow.tsx
@@ -160,3 +160,4 @@ export const IressShadow = forwardRef<ShadowRoot | null, IressShadowProps>(
     );
   },
 );
+IressShadow.displayName = 'IressShadow';


### PR DESCRIPTION
This pull request standardizes the addition of `displayName` properties to many React components in the `packages/components` library. This improves debugging and developer experience by making component names more readable in React DevTools and error messages. The changes also update the type signatures for several components that use `forwardRef` to ensure the `displayName` property is included in their types.

**React component improvements:**

* Added `displayName` properties to the following components: `IressAlert`, `AutocompleteInstructions`, `IressBadge`, `IressButtonGroup`, `IressCheckboxMark`, `IressCol`, `IressContainer`, `IressDivider`, `IressExpander`, `IressField`, `IressFieldGroup`, `FieldFooter`, `FieldHint`, `FilterLabel`, and `FilterResultsDescriptor` (`[[1]](diffhunk://#diff-1eb4efad920c91368710694b03f8d927d23ef37b83ae94dc37de86b6bcd33ad2R189-R190)`, `[[2]](diffhunk://#diff-ba75cda776260f2320d7e364d3596e2fe6664a5c8f8a54f2bd86a4f35d587e45R17-R18)`, `[[3]](diffhunk://#diff-4d6fed61af00f9ef64010418dc359c3ee0a17b1f8af6b5512985b30d806740cbR67-R68)`, `[[4]](diffhunk://#diff-431fd98658aa6519f040d7aa2cb3aeee94e1b057b07abe3e5af0c23489107829R98-R99)`, `[[5]](diffhunk://#diff-be06ab270aac6d675f1ddbf3a4ca9a12951ae880488ddf049f937f0c56210ad7R61-R62)`, `[[6]](diffhunk://#diff-8339b30386375996008a1524807e66f10fddc08c5ef1cc0542550580954bf31dR41-R42)`, `[[7]](diffhunk://#diff-caf8c82c3b34b2fa54e91a1afd68d1dcf4dda3b15b056c3276c652c4a7d71079R31-R32)`, `[[8]](diffhunk://#diff-36c999561326674dfb625cf7ceaea7f8af021806e2ccc44a02b0f5eb7d368263R35-R36)`, `[[9]](diffhunk://#diff-10e5732cfe9cdce606780ccb7e64624e4e2ccb91c88b2da6d63c61f130c76d55R114-R115)`, `[[10]](diffhunk://#diff-c93209e0f0d16e31636094f9aa26d73873463a85abbaf108a6197fd12fb2536fR180-R181)`, `[[11]](diffhunk://#diff-8d6a82070d08f252f52380eb3cd6ae2146b5ad90db91d2844e5c817ef88c8b7fR95-R96)`, `[[12]](diffhunk://#diff-fe064becc53dba15f655fcc934a46c19d42f13636f9bcc7a30dcf24f034dd586R98-R99)`, `[[13]](diffhunk://#diff-28343cd2fa973305318b432f8fe538a02501048f827773fd24e1b2165b048543R80-R81)`, `[[14]](diffhunk://#diff-d3292e2224e7d5c36d86ca74ef11b01ce12c2d49b9bccef69ce30c133c3c40bfR25-R26)`, `[[15]](diffhunk://#diff-581c45cc2b643390cf3d14a8a4b47315cb6de170f42dbe52072c4dcf97cdb458R47-R48)`).

**Type and forwardRef enhancements:**

* Updated the type signatures for `IressButton`, `IressCheckbox`, `IressCheckboxGroup`, and `IressFilter` to include the `displayName` property in their types, ensuring type safety and consistency (`[[1]](diffhunk://#diff-6c0124f2c994da677b1e58b8dd0330a419db03ba9238bea221013803a68d3c6cL279-R290)`, `[[2]](diffhunk://#diff-dac4d78e57f6f5e6c8ffb755a52e52e1d36bf27dc36191781753b2860c17e04fL258-R266)`, `[[3]](diffhunk://#diff-f9a56aec3a9b969a14563aa0abef2fcccbb8d3800f937f08912814646957db00L198-R208)`, `[[4]](diffhunk://#diff-83acfec2613417f08dbe1e4a30260bc9d03c6d0e39946c5427dda554bd539b3bL351-R361)`).

**Card component improvements:**

* Added `displayName` properties to `IressCard`, `IressButtonCard`, and `IressLinkCard` for better identification in development tools (`[packages/components/src/components/Card/Card.tsxR174-R188](diffhunk://#diff-03e16934c03c60142cb18d422b057595eb9e09774eb87846b3a1c0cd508e8651R174-R188)`).