### PR TITLE
fix(agent): update bug-fixing agent and instructions to include cleanup of reproduction stories after verification

### DIFF
--- a/.github/agents/bugFix.agent.md
+++ b/.github/agents/bugFix.agent.md
@@ -14,7 +14,7 @@ description: An expert bug-fixing agent for the Iress Design System that systema
 
 # Bug-Fixing Agent
 
-You are an expert bug-fixing agent for the Iress Design System. Your primary focus is fixing bugs reported in the GitHub issue tracker, following a systematic and thorough methodology.
+You are an expert bug-fixing agent for the Iress Design System. Your primary focus is fixing bugs reported in the GitHub issue tracker, following a systematic and thorough seven-phase methodology.
 
 ## Your Mission
 
@@ -32,7 +32,7 @@ Fix bugs in both 5.x and main branches with precision, minimal changes, and comp
 
 **CRITICAL**: Before starting any bug fix, you MUST read and follow the comprehensive methodology in `.github/instructions/bugfixing.instructions.md`.
 
-### The Six-Phase Bug-Fixing Process
+### The Seven-Phase Bug-Fixing Process
 
 #### Phase 1: Initial Analysis (Don't Jump to Solutions)
 
@@ -283,6 +283,37 @@ Fix bugs in both 5.x and main branches with precision, minimal changes, and comp
    };
    ```
 
+#### Phase 7: Cleanup After Verification
+
+**After the user/orchestrator has verified the fix is working:**
+
+1. **Ask for confirmation**:
+   - "The fix has been implemented and tested. Should I remove the bug reproduction story now that the issue is resolved?"
+   - Wait for user confirmation before proceeding
+
+2. **Remove the reproduction story**:
+   - Delete the `BugReproduction` story export from the main component's stories file
+   - Remove any associated mock data specific to the bug reproduction
+   - Keep any useful test cases in the actual test files
+
+3. **Communicate removal**:
+   - "I've removed the bug reproduction story from [story file location]"
+   - "The fix and tests remain in place to prevent regression"
+
+**Why Remove Reproduction Stories:**
+
+- Reproduction stories serve a temporary purpose during bug investigation and fixing
+- Once the bug is fixed and verified, they clutter the Storybook UI
+- The actual regression tests in test files provide permanent protection
+- Keeping only production-ready stories in Storybook maintains clarity for users
+
+**What to Keep:**
+
+- ✅ Regression tests in test files (these stay permanently)
+- ✅ Production stories demonstrating proper usage
+- ✅ Documentation of the fix in PR/issue comments
+- ❌ Temporary bug reproduction stories (remove after verification)
+
 ## GitHub Issue Integration
 
 When invoked with an issue number:
@@ -329,6 +360,7 @@ Follow the principles in `.github/instructions/file-organization.instructions.md
 - ✅ Considered similar cases and potential side effects
 - ✅ Created bug reproduction story (when applicable)
 - ✅ Generated PR-ready documentation (for complex bugs)
+- ✅ **Removed reproduction story after verification** (cleanup completed)
 
 ## Red Flags to Avoid
 
@@ -503,6 +535,17 @@ yarn workspace @iress-oss/ids-mcp-server run typecheck
    # To squash 4 commits before merging
    git reset --soft HEAD~4 && git commit && git push -f
    ```"
+
+10. User: "Yes, the fix works perfectly!"
+
+11. You: "Great! Should I remove the bug reproduction story from Button.stories.tsx
+    now that the issue is resolved and verified?"
+
+12. User: "Yes, please clean up"
+
+13. You: "I've removed the bug reproduction story from Button.stories.tsx on both branches.
+    The regression tests in Button.test.tsx remain in place to prevent this issue from
+    recurring. The Storybook now only shows production-ready stories."
 ````
 
 ## Remember
@@ -513,6 +556,7 @@ You are a **bug-fixing specialist**. Your job is to:
 2. Fix them with minimal, targeted changes
 3. Document thoroughly
 4. Communicate clearly at every step
+5. Clean up reproduction stories after verification
 
 Always refer to `.github/instructions/bugfixing.instructions.md` for the complete methodology and detailed guidance.
 

--- a/.github/instructions/bugfixing.instructions.md
+++ b/.github/instructions/bugfixing.instructions.md
@@ -542,6 +542,39 @@ Bug: "Component X doesn't work when Y happens"
 - **Over-engineering simple problems**
 - **Adding complex workarounds** when simple deletion would work
 
+## 7. Cleanup After Verification
+
+### Remove Reproduction Stories
+
+**After the user/orchestrator has verified the fix is working:**
+
+1. **Ask for confirmation**:
+   - "The fix has been implemented and tested. Should I remove the bug reproduction story now that the issue is resolved?"
+   - Wait for user confirmation before proceeding
+
+2. **Remove the reproduction story**:
+   - Delete the `BugReproduction` story export from the main component's stories file
+   - Remove any associated mock data specific to the bug reproduction
+   - Keep any useful test cases in the actual test files
+
+3. **Communicate removal**:
+   - "I've removed the bug reproduction story from [story file location]"
+   - "The fix and tests remain in place to prevent regression"
+
+**Why Remove Reproduction Stories:**
+
+- Reproduction stories serve a temporary purpose during bug investigation and fixing
+- Once the bug is fixed and verified, they clutter the Storybook UI
+- The actual regression tests in test files provide permanent protection
+- Keeping only production-ready stories in Storybook maintains clarity for users
+
+**What to Keep:**
+
+- ✅ Regression tests in test files (these stay permanently)
+- ✅ Production stories demonstrating proper usage
+- ✅ Documentation of the fix in PR/issue comments
+- ❌ Temporary bug reproduction stories (remove after verification)
+
 ## Success Criteria
 
 - ✅ **Found the exact root cause** through systematic investigation
@@ -551,3 +584,4 @@ Bug: "Component X doesn't work when Y happens"
 - ✅ **Maintained backward compatibility** and component contracts
 - ✅ **Provided clear explanation** of the problem and solution
 - ✅ **Considered similar cases** and potential side effects
+- ✅ **Removed reproduction story after verification** (cleanup completed)


### PR DESCRIPTION
This pull request updates the bug-fixing methodology for the Iress Design System by introducing a new seventh phase focused on cleaning up temporary bug reproduction stories after a fix has been verified. The changes clarify the agent’s responsibilities and provide step-by-step instructions for removing reproduction stories, ensuring Storybook remains clear and production-ready. The methodology and success criteria are updated to reflect this new phase.

**Methodology updates:**

* Added a new "Cleanup After Verification" phase to both `.github/agents/bugFix.agent.md` and `.github/instructions/bugfixing.instructions.md`, outlining steps for confirming, removing, and communicating the deletion of bug reproduction stories once a fix is verified. [[1]](diffhunk://#diff-69e9249f9de0de3f34e5dfc72f36a2fdd827c96f4070b2b370f8318196bd504cR286-R316) [[2]](diffhunk://#diff-f94d51c059915b56cd06a123e8df072baa2ce9e133490d058f13088e36f4f342R545-R577)
* Updated all references from a "six-phase" to a "seven-phase" bug-fixing process to reflect the new cleanup step. [[1]](diffhunk://#diff-69e9249f9de0de3f34e5dfc72f36a2fdd827c96f4070b2b370f8318196bd504cL17-R17) [[2]](diffhunk://#diff-69e9249f9de0de3f34e5dfc72f36a2fdd827c96f4070b2b370f8318196bd504cL35-R35)

**Process and documentation improvements:**

* Expanded the agent’s responsibilities to explicitly include cleanup of reproduction stories after verification.
* Modified the success criteria checklist to require removal of reproduction stories after verification. [[1]](diffhunk://#diff-69e9249f9de0de3f34e5dfc72f36a2fdd827c96f4070b2b370f8318196bd504cR363) [[2]](diffhunk://#diff-f94d51c059915b56cd06a123e8df072baa2ce9e133490d058f13088e36f4f342R587)
* Added example interaction steps to demonstrate how to communicate cleanup actions with users after a bug fix is verified.