### PR TITLE
fix(agent): add cleanup instructions for bug reproduction stories after verification

### DIFF
--- a/.github/agents/bugFix.agent.md
+++ b/.github/agents/bugFix.agent.md
@@ -267,6 +267,29 @@ Fix bugs in both 5.x and main branches with precision, minimal changes, and comp
    };
    ```
 
+#### Phase 7: Cleanup After Verification
+
+**After the user/orchestrator confirms the fix is working:**
+
+1. **Remove Bug Reproduction Story**:
+   - Delete the entire bug reproduction story from the component's stories file
+   - Remove any mock data created specifically for the bug story
+   - Bug stories served their purpose during development
+   - The fix is protected by unit tests, not stories
+   - Keep Storybook clean and focused on usage examples
+
+2. **Cleanup Process**:
+   - Wait for explicit confirmation that the fix works
+   - Remove the story export from the stories file
+   - Create a separate commit for cleanup: `chore: remove bug reproduction story`
+   - Push the cleanup commit
+
+3. **Communicate Cleanup**:
+   - "Now that you've verified the fix, I'll remove the bug reproduction story to keep Storybook clean"
+   - "Story removed. The fix is still protected by the test I added in `[Component].test.tsx`"
+
+**Important**: Never remove the story until the user explicitly confirms the fix is working.
+
 ## GitHub Issue Integration
 
 When invoked with an issue number:
@@ -313,6 +336,7 @@ Follow the principles in `.github/instructions/file-organization.instructions.md
 - ✅ Considered similar cases and potential side effects
 - ✅ Created bug reproduction story (when applicable)
 - ✅ Generated PR-ready documentation (for complex bugs)
+- ✅ **Removed bug reproduction story after verification**
 
 ## Red Flags to Avoid
 
@@ -491,6 +515,15 @@ yarn build:affected
    # I made 4 commits (fix, test, versions, docs)
    git reset --soft HEAD~4 && git commit && git push -f
    ```"
+
+10. User: "I've tested the fix on both branches, it works perfectly!"
+
+11. You: "Great! Now that you've verified the fix works, I'll clean up by removing
+    the bug reproduction story from Button.stories.tsx on both branches.
+    The fix is still protected by the unit tests I added."
+    [Removes bug reproduction story, commits cleanup]
+    "Bug reproduction story removed on both branches. Storybook is now clean
+    and focused on proper usage examples."
 ````
 
 ## Remember

--- a/.github/instructions/bugfixing.instructions.md
+++ b/.github/instructions/bugfixing.instructions.md
@@ -542,6 +542,58 @@ Bug: "Component X doesn't work when Y happens"
 - **Over-engineering simple problems**
 - **Adding complex workarounds** when simple deletion would work
 
+## 7. Cleanup After Verification
+
+### Remove Bug Reproduction Stories
+
+**After the user/orchestrator has verified the fix works:**
+
+- **Remove the bug reproduction story** from the component's stories file
+- Bug reproduction stories served their purpose during development and testing
+- The actual fix is validated by unit tests, not stories
+- Keeping reproduction stories clutters the Storybook documentation
+- Stories should demonstrate proper usage, not past bugs
+
+**Process:**
+
+1. **Wait for verification**: Don't remove until user confirms fix works
+2. **Remove the story export**: Delete the entire `BugReproduction` story export
+3. **Clean up test data**: Remove any mock data created specifically for the bug story
+4. **Commit the cleanup**: Create a separate commit for story removal
+5. **Communicate**: "I've removed the bug reproduction story now that the fix is verified"
+
+**Example cleanup:**
+
+```typescript
+// Before cleanup - Bug reproduction story present
+export const BugReproduction: Story = {
+  name: 'Bug: [Brief Description]',
+  args: {
+    /* ... */
+  },
+  // ... story configuration
+};
+
+// After cleanup - Story removed, only proper usage examples remain
+export const Default: Story = {
+  /* ... */
+};
+export const WithOptions: Story = {
+  /* ... */
+};
+```
+
+**When to keep reproduction stories:**
+
+- **Never** - bug reproduction stories should always be removed after verification
+- The test suite provides regression prevention
+- Storybook is for documentation and usage examples, not bug tracking
+
+**Communicate cleanup:**
+
+- "Now that you've verified the fix, I'll remove the bug reproduction story to keep Storybook clean"
+- "Story removed. The fix is still protected by the test I added in `[Component].test.tsx`"
+
 ## Success Criteria
 
 - ✅ **Found the exact root cause** through systematic investigation
@@ -551,3 +603,4 @@ Bug: "Component X doesn't work when Y happens"
 - ✅ **Maintained backward compatibility** and component contracts
 - ✅ **Provided clear explanation** of the problem and solution
 - ✅ **Considered similar cases** and potential side effects
+- ✅ **Removed bug reproduction story after verification**


### PR DESCRIPTION
This pull request updates the bug-fixing process documentation to emphasize the importance of cleaning up bug reproduction stories in Storybook after a fix has been verified. The changes clarify when and how to remove these stories, ensuring Storybook remains focused on usage examples and not cluttered with past bug reproductions.

**Bug Reproduction Story Cleanup Process:**

* Added a new section detailing the steps for removing bug reproduction stories from component stories files after the fix has been confirmed, including waiting for explicit user verification, deleting related mock data, creating a separate cleanup commit, and communicating the cleanup to the team. (.github/agents/bugFix.agent.md) [[1]](diffhunk://#diff-69e9249f9de0de3f34e5dfc72f36a2fdd827c96f4070b2b370f8318196bd504cR270-R292) [[2]](diffhunk://#diff-f94d51c059915b56cd06a123e8df072baa2ce9e133490d058f13088e36f4f342R545-R596)
* Updated the bug-fixing checklist to include confirmation that bug reproduction stories are removed after verification. (.github/agents/bugFix.agent.md, .github/instructions/bugfixing.instructions.md) [[1]](diffhunk://#diff-69e9249f9de0de3f34e5dfc72f36a2fdd827c96f4070b2b370f8318196bd504cR339) [[2]](diffhunk://#diff-f94d51c059915b56cd06a123e8df072baa2ce9e133490d058f13088e36f4f342R606)
* Provided example communication and commit messages for the cleanup phase, and included a practical example of story removal in TypeScript. (.github/agents/bugFix.agent.md, .github/instructions/bugfixing.instructions.md) [[1]](diffhunk://#diff-69e9249f9de0de3f34e5dfc72f36a2fdd827c96f4070b2b370f8318196bd504cR518-R526) [[2]](diffhunk://#diff-f94d51c059915b56cd06a123e8df072baa2ce9e133490d058f13088e36f4f342R545-R596)