### PR TITLE
fix(alpha): contains and stretched text area

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^4.1.3",
-    "@iress-oss/ids-components": "^6.0.0-alpha.20",
+    "@iress-oss/ids-components": "^6.0.0-alpha.21",
     "@iress-oss/ids-storybook-config": "^0.2.13",
     "@iress-oss/ids-storybook-okta": "^0.1.2",
     "@iress-oss/ids-storybook-sandbox": "^0.2.2",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iress-oss/ids-components",
-  "version": "6.0.0-alpha.20",
+  "version": "6.0.0-alpha.21",
   "description": "Iress React Component Library",
   "license": "Apache-2.0",
   "type": "module",
@@ -54,7 +54,6 @@
     "jest-axe": "10.0.0",
     "jsdom": "27.4.0",
     "lightningcss": "^1.30.2",
-    "material-symbols": "0.40.2",
     "postcss": "8.4.31",
     "prettier": "^3.7.4",
     "react": "^19.2.1",
@@ -77,6 +76,7 @@
     "@tanstack/react-table": "8.21.3",
     "@types/mdx": "^2.0.13",
     "fuzzysort": "3.1.0",
+    "material-symbols": "0.40.2",
     "query-selector-shadow-dom": "1.0.1",
     "use-debounce": "10.0.6"
   },

--- a/packages/components/src/components/Input/Input.styles.ts
+++ b/packages/components/src/components/Input/Input.styles.ts
@@ -5,7 +5,7 @@ export const input = sva({
   base: {
     wrapper: {
       // Performance: CSS containment limits style recalculation scope
-      contain: 'style paint',
+      contain: 'style',
       display: 'flex',
       alignItems: 'stretch',
       borderRadius: 'radius.system.form',
@@ -223,5 +223,16 @@ export const input = sva({
       },
     },
   },
+  compoundVariants: [
+    {
+      isTextarea: true,
+      stretched: true,
+      css: {
+        formControl: {
+          height: '[100%]',
+        },
+      },
+    },
+  ],
   defaultVariants: {},
 });

--- a/packages/components/src/components/Panel/Panel.styles.ts
+++ b/packages/components/src/components/Panel/Panel.styles.ts
@@ -3,7 +3,7 @@ import { cva } from '@/styled-system/css';
 export const panel = cva({
   base: {
     // Performance: CSS containment (no paint to allow overflow)
-    contain: 'layout style',
+    contain: 'style',
     display: 'block',
     boxSizing: 'border-box',
     borderRadius: 'radius.system.layout',

--- a/packages/components/src/components/RichSelect/RichSelect.styles.ts
+++ b/packages/components/src/components/RichSelect/RichSelect.styles.ts
@@ -11,7 +11,7 @@ export const richSelect = sva({
   base: {
     richSelect: {
       // Performance: CSS containment (no paint to allow focus ring/shadow)
-      contain: 'layout style',
+      contain: 'style',
       display: 'block',
     },
     popoverContent: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1361,7 +1361,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@iress-oss/ids-components@npm:^6.0.0-alpha.20, @iress-oss/ids-components@workspace:packages/components":
+"@iress-oss/ids-components@npm:^6.0.0-alpha.21, @iress-oss/ids-components@workspace:packages/components":
   version: 0.0.0-use.local
   resolution: "@iress-oss/ids-components@workspace:packages/components"
   dependencies:
@@ -1727,7 +1727,7 @@ __metadata:
   resolution: "@iress/design-system-monorepo@workspace:."
   dependencies:
     "@chromatic-com/storybook": "npm:^4.1.3"
-    "@iress-oss/ids-components": "npm:^6.0.0-alpha.20"
+    "@iress-oss/ids-components": "npm:^6.0.0-alpha.21"
     "@iress-oss/ids-storybook-config": "npm:^0.2.13"
     "@iress-oss/ids-storybook-okta": "npm:^0.1.2"
     "@iress-oss/ids-storybook-sandbox": "npm:^0.2.2"


### PR DESCRIPTION
This pull request contains a version bump for the `@iress-oss/ids-components` package, dependency adjustments, and several style improvements to component containment and layout. The main focus is on updating dependencies and refining CSS containment for better performance and behavior, as well as introducing a new compound variant for the `Input` component.

**Dependency and version updates:**

* Bumped `@iress-oss/ids-components` to version `6.0.0-alpha.21` in both the root `package.json` and `packages/components/package.json`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L15-R15) [[2]](diffhunk://#diff-2c76dc06185f93bec73660e15338433b95eac6707317564c0f778f5b9abe446cL3-R3)
* Moved the `material-symbols` package from `devDependencies` to `dependencies` in `packages/components/package.json` for correct usage and bundling. [[1]](diffhunk://#diff-2c76dc06185f93bec73660e15338433b95eac6707317564c0f778f5b9abe446cL57) [[2]](diffhunk://#diff-2c76dc06185f93bec73660e15338433b95eac6707317564c0f778f5b9abe446cR79)

**Component style and containment improvements:**

* Updated the `contain` CSS property from `'style paint'` or `'layout style'` to just `'style'` in the `Input`, `Panel`, and `RichSelect` components to optimize containment and allow proper overflow and focus ring rendering. [[1]](diffhunk://#diff-522a8f8c09a051563935fd3737fbd7ebb1159de461168085ed9ed455fa4834b9L8-R8) [[2]](diffhunk://#diff-39b69aa83872c4e5550fb812c786d94f59fce24d83eb0aad156b7807fcfbc394L6-R6) [[3]](diffhunk://#diff-e47adaa28098bae3e1515508861d0cb97ce88a0e4b2edf50cbdea35cb9ec397aL14-R14)
* Added a new `compoundVariant` to the `Input` component styles to ensure that when both `isTextarea` and `stretched` are true, the `formControl` receives a height of `100%`.