### PR TITLE
fix(alpha): Icon: adjust Icon component to have font weight

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^4.1.3",
-    "@iress-oss/ids-components": "^6.0.0-alpha.22",
-    "@iress-oss/ids-storybook-config": "^0.2.13",
+    "@iress-oss/ids-components": "^6.0.0-alpha.23",
+    "@iress-oss/ids-storybook-config": "^0.3.0",
     "@iress-oss/ids-storybook-okta": "^0.1.2",
     "@iress-oss/ids-storybook-sandbox": "^0.2.2",
     "@iress-oss/ids-storybook-toggle-stories": "^0.1.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iress-oss/ids-components",
-  "version": "6.0.0-alpha.22",
+  "version": "6.0.0-alpha.23",
   "description": "Iress React Component Library",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/components/src/components/Icon/Icon.constants.ts
+++ b/packages/components/src/components/Icon/Icon.constants.ts
@@ -1,4 +1,6 @@
 export const MATERIAL_SYMBOLS = {
+  family: 'Material Symbols Rounded',
+  className: 'material-symbols-rounded',
   figmaGrade: 'Emphasis',
   figmaOpticalSize: '24dp',
   grade: 0,

--- a/packages/components/src/components/Icon/Icon.styles.ts
+++ b/packages/components/src/components/Icon/Icon.styles.ts
@@ -1,4 +1,5 @@
 import { cva } from '@/styled-system/css';
+import { MATERIAL_SYMBOLS } from './Icon.constants';
 
 export const icon = cva({
   base: {},
@@ -7,6 +8,7 @@ export const icon = cva({
       fontawesome: {},
       material: {
         fontFamily: 'Material Symbols Rounded',
+        fontWeight: MATERIAL_SYMBOLS.weight,
         textStyle: 'inherit',
         verticalAlign: 'middle',
         materialSymbols: 'true',

--- a/packages/components/src/components/Icon/Icon.tsx
+++ b/packages/components/src/components/Icon/Icon.tsx
@@ -12,6 +12,7 @@ import {
   FA_TO_MATERIAL_MAP,
   type FontAwesomeIconWithMaterialEquivalent,
 } from './helpers/iconMapping';
+import { MATERIAL_SYMBOLS } from './Icon.constants';
 
 export type IressIconProps<P extends IconType = 'material'> =
   IressStyledProps<'span'> & {
@@ -131,7 +132,7 @@ export const IressIcon = <P extends IconType = 'material'>({
         className={cx(
           css(styles, styleProps),
           GlobalCSSClass.Icon,
-          'material-symbols-rounded',
+          MATERIAL_SYMBOLS.className,
           className,
         )}
         aria-hidden={!screenreaderText && 'true'}

--- a/packages/storybook-config/package.json
+++ b/packages/storybook-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iress-oss/ids-storybook-config",
-  "version": "0.2.13",
+  "version": "0.3.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1379,7 +1379,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@iress-oss/ids-components@npm:^6.0.0-alpha.22, @iress-oss/ids-components@workspace:packages/components":
+"@iress-oss/ids-components@npm:^6.0.0-alpha.23, @iress-oss/ids-components@workspace:packages/components":
   version: 0.0.0-use.local
   resolution: "@iress-oss/ids-components@workspace:packages/components"
   dependencies:
@@ -1470,7 +1470,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@iress-oss/ids-storybook-config@npm:^0.2.13, @iress-oss/ids-storybook-config@workspace:packages/storybook-config":
+"@iress-oss/ids-storybook-config@npm:^0.3.0, @iress-oss/ids-storybook-config@workspace:packages/storybook-config":
   version: 0.0.0-use.local
   resolution: "@iress-oss/ids-storybook-config@workspace:packages/storybook-config"
   dependencies:
@@ -1745,8 +1745,8 @@ __metadata:
   resolution: "@iress/design-system-monorepo@workspace:."
   dependencies:
     "@chromatic-com/storybook": "npm:^4.1.3"
-    "@iress-oss/ids-components": "npm:^6.0.0-alpha.22"
-    "@iress-oss/ids-storybook-config": "npm:^0.2.13"
+    "@iress-oss/ids-components": "npm:^6.0.0-alpha.23"
+    "@iress-oss/ids-storybook-config": "npm:^0.3.0"
     "@iress-oss/ids-storybook-okta": "npm:^0.1.2"
     "@iress-oss/ids-storybook-sandbox": "npm:^0.2.2"
     "@iress-oss/ids-storybook-toggle-stories": "npm:^0.1.0"


### PR DESCRIPTION
This pull request updates several dependencies and refactors the way Material Symbols icon constants are managed and used in the `@iress-oss/ids-components` package. The most significant changes include centralizing Material Symbols properties into a single constants file and ensuring consistent usage throughout the Icon component's codebase.

**Dependency updates:**

* Upgraded `@iress-oss/ids-components` to version `6.0.0-alpha.23` and `@iress-oss/ids-storybook-config` to version `0.3.0` in both the root `package.json` and their respective package files. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L15-R16) [[2]](diffhunk://#diff-2c76dc06185f93bec73660e15338433b95eac6707317564c0f778f5b9abe446cL3-R3) [[3]](diffhunk://#diff-46d0795107ec547606361f1e84b021aec85532a321ea35e8823b9f3abd717276L3-R3)

**Icon component refactoring:**

* Added `family` and `className` properties to the `MATERIAL_SYMBOLS` constant in `Icon.constants.ts` to centralize Material Symbols configuration.
* Updated `Icon.styles.ts` to import `MATERIAL_SYMBOLS` and use its `weight` property for the material icon style, ensuring consistent styling. [[1]](diffhunk://#diff-89becb7bc3ad5ab04099e37251f82c938c74a5fc50bfd293ff7462e70837d0d4R2) [[2]](diffhunk://#diff-89becb7bc3ad5ab04099e37251f82c938c74a5fc50bfd293ff7462e70837d0d4R11)
* Updated `Icon.tsx` to import and use `MATERIAL_SYMBOLS.className` instead of hardcoding the class name, improving maintainability and reducing duplication. [[1]](diffhunk://#diff-301eb2855097679c475c778d2386f4cdebcb1b09be283eacc20380be036ebf2fR15) [[2]](diffhunk://#diff-301eb2855097679c475c778d2386f4cdebcb1b09be283eacc20380be036ebf2fL134-R135)