### PR TITLE
Add migration scripts and update documentation for IDS v6

### DIFF
--- a/.agents/skills/version-migration/SKILL.md
+++ b/.agents/skills/version-migration/SKILL.md
@@ -16,19 +16,35 @@ description: Guide AI agents on migrating applications between IDS (Iress Design
 
 ## Decision Table: Which Migration Path?
 
-| Current stack | Migration path                       | Complexity                      |
-| ------------- | ------------------------------------ | ------------------------------- |
-| OUI only      | OUI→v6 guide                         | High (form architecture change) |
-| IDS v4 only   | v5→v6 guide (skip v5 step)           | Medium                          |
-| IDS v5 only   | v5→v6 guide                          | Low–Medium                      |
-| OUI + IDS v4  | Both OUI→v6 and v5→v6 guides         | High                            |
-| OUI + IDS v5  | OUI→v6 guide + v5→v6 for IDS changes | High                            |
+| Current stack | Migration path                       | Complexity                        | Reference                                                 |
+| ------------- | ------------------------------------ | --------------------------------- | --------------------------------------------------------- |
+| OUI only      | OUI→v6 guide                         | High (form architecture change)   | [prop-renames.md](references/prop-renames.md)             |
+| IDS v4 only   | v4→v6 guide                          | Medium (form architecture change) | [prop-renames.md](references/prop-renames.md)             |
+| IDS v5 only   | v5→v6 guide                          | Low–Medium                        | [v5-to-v6-migration.md](references/v5-to-v6-migration.md) |
+| OUI + IDS v4  | Both OUI→v6 and v4→v6 guides         | High (form architecture change)   | [prop-renames.md](references/prop-renames.md)             |
+| OUI + IDS v5  | OUI→v6 guide + v5→v6 for IDS changes | High (form architecture change)   | [v5-to-v6-migration.md](references/v5-to-v6-migration.md) |
 
 Full interactive guides with diff viewers are available in Storybook:
 
 - [v4→v5 guide](https://main--691abcc79dfa560a36d0a74f.chromatic.com/?path=/docs/resources-migration-guides-from-v4-to-v5--docs)
 - [v5→v6 guide](https://main--691abcc79dfa560a36d0a74f.chromatic.com/?path=/docs/resources-migration-guides-from-v5-to-v6--docs)
 - [OUI→v6 guide](https://main--691abcc79dfa560a36d0a74f.chromatic.com/?path=/docs/resources-migration-guides-from-oui-to-v6--docs)
+
+---
+
+## Pre-Migration Assessment
+
+Before starting migration, run these scripts (or perform checks manually):
+
+1. **Identify current version**: `scripts/detect-version.sh` — detects IDS/OUI version and recommends migration path
+2. **Audit component usage**: `scripts/audit-components.sh` — generates component usage report
+3. **Check for deprecated props**: `scripts/find-deprecated-props.sh` — finds props that will break
+4. **Check form architecture**: `scripts/find-formik.sh` — identifies Formik forms needing migration
+5. **Check test patterns**: `scripts/find-test-utils.sh` — finds old test utilities
+6. **Review custom CSS**: Search for `.oui-`, `.ids-`, or `iress-` class selectors that may break
+7. **Setup VRT (recommended)**: `scripts/setup-playwright-vrt.sh` — generates Playwright visual regression tests
+8. **Capture baseline screenshots**: Run VRT suite before migration to capture current state
+9. **Create migration branch**: Ensure you can rollback if needed
 
 ---
 
@@ -66,6 +82,16 @@ import { cssVars } from '@iress-oss/ids-tokens';
 
 ## Key Migration Areas
 
+### v5 → v6 Migration
+
+For migrations specifically from IDS v5 to v6, see [references/v5-to-v6-migration.md](references/v5-to-v6-migration.md) for:
+
+- Package and CSS import changes
+- Component renames (`IressBadge` → `IressPill`, `IressFilter` → `IressDropdownMenu`, etc.)
+- Prop changes by component (Button, Alert, Toggle, Field, Modal, Select)
+- Icon migration (FontAwesome → Material Symbols)
+- Form migration patterns
+
 ### Component renames
 
 Components that changed names between versions (IDS and OUI → v6), plus removed and new components. See [references/component-renames.md](references/component-renames.md) for the full map.
@@ -78,7 +104,14 @@ Using old prop names will silently fail. See [references/prop-renames.md](refere
 
 Most common renames:
 
-| Component                  | Old prop     | New prop (v6)  |
+| Component               | Old prop (OUI) | New prop (v6)  |
+| ----------------------- | -------------- | -------------- |
+| `Alert`                 | `context`      | `status`       |
+| `Modal`                 | `onHide`       | `onShowChange` |
+| `Fieldset`/`RadioGroup` | `legend`       | `label`        |
+| `Label`                 | `optional`     | `required`     |
+
+| Component (IDS v4/v5)      | Old prop     | New prop (v6)  |
 | -------------------------- | ------------ | -------------- |
 | `IressButton`              | `variant`    | `mode`         |
 | `IressAlert`               | `variant`    | `status`       |
@@ -124,21 +157,38 @@ See [references/styling-migration.md](references/styling-migration.md) for examp
 
 ---
 
+## Post-Migration Validation
+
+After completing migration, run `scripts/validate-migration.sh` or verify manually:
+
+1. **Automated checks**: Run validation script to check for common issues
+2. **Visual regression**: Run VRT suite and review all visual diffs (see [references/visual-regression-testing.md](references/visual-regression-testing.md))
+3. **Visual check**: All components render without console errors or warnings
+4. **Form functionality**: Submit forms and verify validation rules work correctly
+5. **Test suite**: All tests pass with new testing patterns (no `idsFireEvent`, etc.)
+6. **Accessibility**: Keyboard navigation and screen reader functionality intact
+7. **Styling**: No missing styles, check responsive breakpoints
+8. **Interactive states**: Hover, focus, disabled, loading states work as expected
+9. **Build**: Production build completes without errors, check bundle size
+
+The validation script checks for:
+- Old imports (`@iress/oui`, `@iress/components-react`)
+- Old test utils (`idsFireEvent`, `mockLazyLoadedComponents`)
+- Deprecated props (`variant=`, `isOpen=`, `gutter=`, etc.)
+- Required CSS import
+- Remaining Formik usage
+
+---
+
 ## Common Gotchas
 
-| Problem                              | Cause                                            | Solution                                                             |
-| ------------------------------------ | ------------------------------------------------ | -------------------------------------------------------------------- |
-| Components have no styles            | Missing CSS import                               | Add `import '@iress-oss/ids-components/dist/style.css'` to app entry |
-| Form validation not working          | Using HTML5 attributes (`required`, `maxLength`) | Move validation to `rules` prop on `IressFormField`                  |
-| Modal won't close                    | Using `isOpen` prop                              | Rename to `show`                                                     |
-| Button variant not applying          | Using `variant` prop                             | Rename to `mode`                                                     |
-| Tests fail "Cannot find module"      | Jest can't transform IDS v6                      | Update `transformIgnorePatterns`                                     |
-| `idsFireEvent` not found             | Using removed IDS v4 test utils                  | Replace with standard `fireEvent` from RTL                           |
-| Form fields render without labels    | Using standalone `<Label>`                       | Move label text into `label` prop on `IressFormField`                |
-| Custom CSS overriding components     | Cascade layer ordering                           | Declare `@layer` order in stylesheet                                 |
-| `IressPanel alt` prop not working    | No boolean `alt` prop exists                     | Use `bg="alt"` instead                                               |
-| `IressAlert mode` not working        | Prop was renamed                                 | Use `status` (e.g. `status="danger"`)                                |
-| `IressFieldGroup legend` not working | Prop was renamed                                 | Use `label` instead                                                  |
+See [references/common-gotchas.md](references/common-gotchas.md) for a comprehensive troubleshooting guide covering:
+
+- Critical breaking changes (missing CSS, validation, renamed props)
+- IDS v4 React → v6 React gotchas (test utils, slots, helpers, icons)
+- OUI-specific gotchas (prop renames, removed components)
+- Component API changes (form fields, styling, composition patterns)
+- Form architecture changes (Formik → React Hook Form)
 
 ---
 

--- a/.agents/skills/version-migration/references/common-gotchas.md
+++ b/.agents/skills/version-migration/references/common-gotchas.md
@@ -1,0 +1,87 @@
+# Common Gotchas
+
+## Critical Breaking Changes
+
+| Problem                              | Cause                                            | Solution                                                             |
+| ------------------------------------ | ------------------------------------------------ | -------------------------------------------------------------------- |
+| Components have no styles            | Missing CSS import                               | Add `import '@iress-oss/ids-components/dist/style.css'` to app entry |
+| Form validation not working          | Using HTML5 attributes (`required`, `maxLength`) | Move validation to `rules` prop on `IressFormField`                  |
+| Modal won't close                    | Using `isOpen` prop (IDS v4/v5)                  | Rename to `show`                                                     |
+| Button variant not applying          | Using `variant` prop (IDS v4/v5)                 | Rename to `mode`                                                     |
+| Tests fail "Cannot find module"      | Jest can't transform IDS v6                      | Update `transformIgnorePatterns`                                     |
+| `idsFireEvent` not found             | Using removed IDS v4 test utils                  | Replace with standard `fireEvent` from RTL                           |
+
+## IDS v4 React → v6 React Gotchas
+
+| Problem                              | Cause                                            | Solution                                                             |
+| ------------------------------------ | ------------------------------------------------ | -------------------------------------------------------------------- |
+| `idsFireEvent` not found             | v4 test utils removed                            | Use standard `fireEvent`/`userEvent` from RTL                        |
+| `mockLazyLoadedComponents` not found | v4 test utils removed                            | Not needed — v6 components load synchronously                        |
+| Slots not rendering                  | v4 uses slots, v6 uses props                     | `<div slot="footer">` → `footer={<div>}` prop                        |
+| `mapRadioGroupOptions` not found     | v4 helper removed                                | Use `<IressRadio>` children directly                                 |
+| `mapCheckboxGroupOptions` not found  | v4 helper removed                                | Use `<IressCheckbox>` children directly                              |
+| `mapTabs` not found                  | v4 helper removed                                | Use `<IressTab>` children directly                                   |
+| `showModal(id)` not found            | v4 helper removed                                | Use `show` prop or `useModal` hook                                   |
+| Button `mode="link"` not working     | Mode removed                                     | Use `mode="tertiary"` or `IressLink` component                       |
+| Button `mode="danger"` not working   | Mode removed                                     | Use `status="danger"` with any mode                                  |
+| Button `mode="positive"` not working | Mode removed                                     | Use `status="success"` with any mode                                 |
+| Alert `status="error"` not working   | Value renamed                                    | Use `status="danger"` instead                                        |
+| Icon `name` not working              | v4 uses FontAwesome, v6 uses Material Symbols    | Replace FA icon names with Material Symbol names                     |
+| Icon `set` prop not working          | Prop removed                                     | v6 uses Material Symbols only                                        |
+| Label `labelText` not working        | v4 uses prop, v6 uses children                   | `<IressLabel>Text</IressLabel>` instead of `labelText="Text"`        |
+| Field validation props not working   | v4 inline validation removed                     | Use `rules` prop on `IressFormField`                                 |
+| Panel `noBorderRadius` not working   | Prop changed                                     | Use `borderRadius="none"` instead                                    |
+| Expander `mode="heading"` not working| Value renamed                                    | Use `mode="section"` instead                                         |
+| SkipLink `targetId` not working      | Prop renamed                                     | Use `href="#targetId"` instead                                       |
+| TabContainer not found               | Component renamed                                | Use `IressTabSet` instead                                            |
+| TabButton/TabPanel not found         | Components merged                                | Use `IressTab` with children for content                             |
+
+## OUI-Specific Gotchas
+
+| Problem                              | Cause                                            | Solution                                                             |
+| ------------------------------------ | ------------------------------------------------ | -------------------------------------------------------------------- |
+| OUI Alert `context` not working      | Prop renamed                                     | Use `status` (e.g. `status="danger"` not `context="danger"`)         |
+| OUI Alert `contextLabel` missing     | Prop removed in v6                               | Alert now auto-generates context labels; remove prop                 |
+| OUI Button children not rendering    | OUI uses `label` prop, v6 uses `children`        | Move `label="Submit"` to `<IressButton>Submit</IressButton>`         |
+| OUI Label not rendering text         | OUI uses `label` prop, v6 uses `children`        | Use `<IressLabel>Text</IressLabel>` or `IressFormField` `label` prop |
+| OUI Modal `onHide` not firing        | Prop renamed                                     | Use `onShowChange` callback                                          |
+| OUI Fieldset `legend` not showing    | Prop renamed                                     | Use `label` prop on `IressFieldGroup`                                |
+| OUI RadioGroup `legend` not showing  | Prop renamed                                     | Use `label` prop on `IressFormField` wrapping `IressRadioGroup`      |
+| OUI Toggle `legend` not showing      | Prop renamed                                     | Use `children` prop on `IressToggle`                                 |
+| OUI Scrollable not working           | Component removed                                | Use `scrollable="y"` styling prop on any component                   |
+| OUI ProgressBar not rendering        | Component renamed                                | Use `IressProgress` instead                                          |
+| OUI Badge not rendering              | Component renamed                                | Use `IressPill` instead                                              |
+
+## Component API Changes
+
+| Problem                              | Cause                                            | Solution                                                             |
+| ------------------------------------ | ------------------------------------------------ | -------------------------------------------------------------------- |
+| Form fields render without labels    | Using standalone `<Label>`                       | Move label text into `label` prop on `IressFormField`                |
+| Custom CSS overriding components     | Cascade layer ordering                           | Declare `@layer` order in stylesheet                                 |
+| `IressPanel alt` prop not working    | No boolean `alt` prop exists                     | Use `bg="alt"` instead                                               |
+| `IressAlert mode` not working        | Prop was renamed                                 | Use `status` (e.g. `status="danger"`)                                |
+| `IressFieldGroup legend` not working | Prop was renamed                                 | Use `label` instead                                                  |
+| `IressButton link` mode not working  | Mode removed                                     | Use `mode="tertiary"` or `IressLink` for paragraph links             |
+| `IressButton danger` mode not working| Mode removed                                     | Use `status="danger"` with any mode                                  |
+| `IressInput` not in form context     | v6 inputs work standalone but forms need wrapper | Wrap with `IressFormField` inside `IressForm`                        |
+| `IressCheckbox` checked not updating | Using `defaultChecked` in controlled mode        | Use `checked` prop for controlled, `defaultChecked` for uncontrolled |
+| `IressRadioGroup` options prop gone  | API changed to composition pattern               | Use `IressRadio` children instead of `options` array                 |
+| `IressToggle` `toggled` prop gone    | Prop renamed                                     | Use `checked` or `defaultChecked`                                    |
+| `IressToggle` `labelTrue/False` gone | API simplified                                   | Use `children` for label; toggle is now binary switch                |
+| `IressSlider` `label` prop gone      | API changed                                      | Use `aria-label` or wrap in `IressFormField`                         |
+| `IressTabs` `activeTabIndex` gone    | API changed                                      | Use `selected`/`defaultSelected` with tab `value` props              |
+| `IressSelect` options format changed | Now uses `LabelValueMeta` objects                | Use `{ label: 'Text', value: 'val' }` format                         |
+| `IressModal` `title` not rendering   | Prop renamed                                     | Use `heading` prop                                                   |
+| `IressSlideout` `eleToPush` selector | Needs valid CSS selector or element ref          | Pass string selector, HTMLElement, or React ref                      |
+
+## Form Architecture Changes
+
+| Problem                              | Cause                                            | Solution                                                             |
+| ------------------------------------ | ------------------------------------------------ | -------------------------------------------------------------------- |
+| Formik `<Field as={}>` not working   | Formik replaced with React Hook Form             | Use `IressFormField` with `render` prop                              |
+| Yup schema validation not working    | Yup replaced with RHF rules                      | Convert to `rules` prop (see form-migration.md)                      |
+| `useFormikContext` not available     | Formik removed                                   | Use `useFormContext` from `react-hook-form`                          |
+| Form `initialValues` not working     | Prop renamed                                     | Use `defaultValues` on `IressForm`                                   |
+| Form `validationSchema` not working  | Yup integration removed                          | Use per-field `rules` on `IressFormField`                            |
+| `setFieldValue` not available        | Formik API removed                               | Use `setValue` from `useFormContext` or form ref                     |
+| Form errors not displaying           | Error handling changed                           | Errors auto-display via `IressFormField`; use `errorMessages` prop   |

--- a/.agents/skills/version-migration/references/component-renames.md
+++ b/.agents/skills/version-migration/references/component-renames.md
@@ -2,25 +2,51 @@
 
 Components that changed names between versions. All other IDS components keep the same name (with the `Iress` prefix in v6).
 
+## IDS v4/v5 → v6 Renames
+
 | Old name             | New name (v6)                                        | Notes                                                |
 | -------------------- | ---------------------------------------------------- | ---------------------------------------------------- |
 | `IressBadge`         | `IressPill`                                          | Renamed in v6                                        |
 | `IressFilter`        | `IressDropdownMenu`                                  | Renamed to pattern component                         |
 | `IressRichSelect`    | `IressSelect`                                        | Renamed; old `IressSelect` replaced by `native` prop |
 | `IressField`         | `IressFormField`                                     | New form-integrated wrapper; `IressField` still exists as a standalone layout component |
-| OUI `Badge`          | `IressPill`                                          | —                                                    |
-| OUI `Button`         | `IressButton`                                        | `variant` → `mode`                                   |
-| OUI `Modal`          | `IressModal`                                         | See prop renames                                     |
-| OUI `DropdownButton` | `IressDropdownMenu` / `IressSelect` / `IressPopover` | Depends on use case                                  |
-| OUI `ProgressBar`    | `IressProgress`                                      | Props unchanged                                      |
-| OUI `Scrollable`     | `scrollable` styling prop                            | Available on any component                           |
-| OUI `Input`          | `IressFormField` + `IressInput`                      | Requires form context                                |
-| OUI `TextArea`       | `IressFormField` + `IressInput`                      | Use `rows` prop                                      |
-| OUI `Label`          | `IressFormField` `label` prop                        | No separate component                                |
-| OUI `FormGroup`      | `IressFormField`                                     | Built into FormField                                 |
-| OUI `Fieldset`       | `IressFieldGroup`                                    | Use `label` prop                                     |
-| OUI `RadioGroup`     | `IressFormField` + `IressRadioGroup`                 | Requires form context                                |
-| OUI `Checkbox`       | `IressFormField` + `IressCheckbox`                   | —                                                    |
+
+## OUI → v6 Renames
+
+| OUI Component        | v6 Component                                         | Notes                                                |
+| -------------------- | ---------------------------------------------------- | ---------------------------------------------------- |
+| `Badge`              | `IressPill`                                          | —                                                    |
+| `Button`             | `IressButton`                                        | OUI uses `label` prop → v6 uses `children`           |
+| `Modal`              | `IressModal`                                         | `onHide` → `onShowChange`; `show` prop unchanged     |
+| `Alert`              | `IressAlert`                                         | `context` → `status`; `contextLabel` removed         |
+| `DropdownButton`     | `IressDropdownMenu` / `IressSelect` / `IressPopover` | Depends on use case                                  |
+| `ProgressBar`        | `IressProgress`                                      | Props mostly unchanged                               |
+| `Scrollable`         | `scrollable` styling prop                            | Available on any component                           |
+| `Input`              | `IressInput`                                         | Can be standalone or wrapped in `IressFormField`     |
+| `TextArea`           | `IressInput` with `rows` prop                        | Use `rows={4}` for textarea behavior                 |
+| `Label`              | `IressLabel` or `IressFormField` `label` prop        | OUI uses `label` prop → v6 uses `children`           |
+| `FormGroup`          | `IressField` or `IressFormField`                     | Built into Field components                          |
+| `Fieldset`           | `IressFieldGroup`                                    | `legend` → `label`                                   |
+| `RadioGroup`         | `IressRadioGroup`                                    | `legend` removed; use `IressFormField` for label     |
+| `Checkbox`           | `IressCheckbox`                                      | Can be standalone or wrapped in `IressFormField`     |
+| `CheckboxGroup`      | `IressCheckboxGroup`                                 | —                                                    |
+| `Slideout`           | `IressSlideout`                                      | `show` prop unchanged                                |
+| `Toggle`             | `IressToggle`                                        | `legend` → `children`; `toggled` → `checked`         |
+| `Tabs`               | `IressTabSet`                                        | `activeTabIndex` → `selected`/`defaultSelected`      |
+| `Tab`                | `IressTab`                                           | —                                                    |
+| `Slider`             | `IressSlider`                                        | `label` removed; use `aria-label` or `IressFormField`|
+| `Tooltip`            | `IressTooltip`                                       | —                                                    |
+| `Popover`            | `IressPopover`                                       | —                                                    |
+| `Card`               | `IressCard`                                          | —                                                    |
+| `Table`              | `IressTable`                                         | —                                                    |
+| `Link`               | `IressLink`                                          | —                                                    |
+| `Nav`                | Removed                                              | Build custom navigation with IDS components          |
+| `NavBar`             | Removed                                              | Build custom navigation with IDS components          |
+| `NavItem`            | Removed                                              | Use `IressSideNav` or custom implementation          |
+| `SingleSelect`       | `IressSelect`                                        | —                                                    |
+| `AutoComplete`       | `IressAutocomplete`                                  | —                                                    |
+| `DatePicker`       | `IressInput` with `type="date"`                      | Native browser date picker                           |
+| `TimePicker`       | `IressInput` with `type="time"`                      | Native browser time picker                           |
 
 ## Removed Components
 
@@ -31,6 +57,15 @@ Components that changed names between versions. All other IDS components keep th
 | `IressToaster` (direct)  | Use `IressToasterProvider` + `useToaster`           |
 | `IressSelectOption`      | Use `options` prop on `IressSelect`                 |
 | `IressHide` (deprecated) | Use `srOnly`, `hideFrom`, or `hideBelow` styling props (component still exported but deprecated) |
+| OUI `Nav`                | Build custom with `IressSideNav` or IDS primitives  |
+| OUI `NavBar`             | Build custom with IDS primitives                    |
+| OUI `NavItem`            | Use `IressSideNav` items or custom implementation   |
+| OUI `NavDropdown`        | Use `IressDropdownMenu` or `IressPopover`           |
+| OUI `DatePicker`         | `IressInput` with `type="date"`                     |
+| OUI `TimePicker`         | `IressInput` with `type="time"`                     |
+| OUI `TreeView`           | Not available in v6                                 |
+| OUI `Onboarding`         | Not available in v6                                 |
+| OUI `Process`            | Not available in v6                                 |
 
 ## New Components in v6
 
@@ -49,3 +84,5 @@ Components that changed names between versions. All other IDS components keep th
 | `IressButtonCard`            | Card rendered as a button                                |
 | `IressLinkCard`              | Card rendered as a link                                  |
 | `IressFormValidationSummary` | Form validation summary alert                            |
+| `IressReadonly`              | Read-only display of form values                         |
+| `IressSpinner`               | Loading spinner                                          |

--- a/.agents/skills/version-migration/references/form-migration.md
+++ b/.agents/skills/version-migration/references/form-migration.md
@@ -37,13 +37,11 @@ function MyForm() {
       {({ errors, touched }) => (
         <Form>
           <FormGroup>
-            <Label htmlFor="email">Email</Label>
+            <Label htmlFor="email" label="Email" />
             <Field name="email" as={Input} type="email" />
             {errors.email && touched.email && <span>{errors.email}</span>}
           </FormGroup>
-          <Button type="submit" variant="primary">
-            Submit
-          </Button>
+          <Button type="submit" mode={Button.Mode.Primary} label="Submit" />
         </Form>
       )}
     </Formik>

--- a/.agents/skills/version-migration/references/prop-renames.md
+++ b/.agents/skills/version-migration/references/prop-renames.md
@@ -4,38 +4,335 @@
 
 These prop names have been verified against the actual IDS v6 source. Using the old prop names will silently fail.
 
-| Component                       | Old prop         | New prop (v6)         | Values                                                      |
-| ------------------------------- | ---------------- | --------------------- | ----------------------------------------------------------- |
-| `IressButton`                   | `variant`        | `mode`                | `"primary"`, `"secondary"`, `"tertiary"`, `"quaternary"`, `"muted"` |
-| `IressButton`                   | —                | `status` (new)        | `"danger"`, `"success"`                                         |
-| `IressButton`                   | —                | `element` (new)       | `"a"` for link rendering                                    |
-| `IressButton`                   | —                | `icon` (new)          | Icon-only button; `children` becomes tooltip                |
-| `IressAlert`                    | `variant`        | `status`              | `"danger"`, `"info"`, `"success"`, `"warning"`, `"neutral"` |
-| `IressAlert`                    | —                | `variant` (new)       | `"sidebar"`, `"full-width"` (layout variant, not color)         |
-| `IressAlert`                    | `error` (value)  | `danger` (value)      | Use `status="danger"` not `status="error"`                  |
-| `IressText`                     | `variant`        | `textStyle`           | —                                                           |
-| `IressText`                     | `mode`           | `color`               | —                                                           |
-| `IressText`                     | `align`          | `textAlign`           | —                                                           |
-| `IressStack`                    | `gutter`         | `gap`                 | Accepts spacing tokens                                      |
-| `IressInline`                   | `gutter`         | `gap`                 | Accepts spacing tokens                                      |
-| `IressDivider`                  | `gutter`         | removed               | Use `my` / `mx` styling props                               |
-| `IressModal`                    | `isOpen`         | `show`                | Boolean                                                     |
-| `IressModal`                    | `onClose`        | `onShowChange`        | `(show: boolean) => void`                                   |
-| `IressModal`                    | `title`          | `heading`             | String or ReactElement                                      |
-| `IressModal`                    | `padding`        | `p` (styling prop)    | —                                                           |
-| `IressPanel`                    | `background`     | `bg`                  | e.g. `bg="alt"` or `bg="colour.neutral.20"`                 |
-| `IressPanel`                    | `padding`        | `p` (styling prop)    | —                                                           |
-| `IressIcon`                     | `mode`           | `color`               | —                                                           |
-| `IressIcon`                     | `size`           | removed               | Inherits font size from parent                              |
-| `IressSkeleton`                 | `textVariant`    | `textStyle`           | —                                                           |
-| `IressLabel`                    | `optional`       | `required` (inverted) | —                                                           |
-| `IressField`                    | `optional`       | `required` (inverted) | —                                                           |
-| `IressFormField`                | `optional`       | via `rules.required`  | Set `rules={{ required: 'msg' }}` instead of a direct prop  |
-| `IressFieldGroup`               | `optional`       | `required` (inverted) | —                                                           |
-| `IressFieldGroup`               | `legend`         | `label`               | String                                                      |
-| `IressCheckbox`                 | `readonly`       | `readOnly`            | —                                                           |
-| `IressRadioGroup`               | `readonly`       | `readOnly`            | —                                                           |
-| `IressSlider`                   | `hiddenOn`       | `srOnly` (styling)    | General styling prop available on all components             |
-| `IressExpander`                 | `mode="heading"` | `mode="section"`      | —                                                           |
-| `IressSkipLink`                 | `targetId`       | `href`                | —                                                           |
-| `IressTable` column             | `align`          | `textAlign`           | —                                                           |
+## OUI → IDS v6 Prop Changes
+
+| OUI Component   | OUI prop        | IDS v6 prop       | Notes                                                       |
+| --------------- | --------------- | ----------------- | ----------------------------------------------------------- |
+| `Alert`         | `context`       | `status`          | Values: `danger`, `info`, `success`, `warning`              |
+| `Alert`         | `contextLabel`  | removed           | v6 auto-generates; remove this prop                         |
+| `Alert`         | `closeLabel`    | `closeLabel`      | Unchanged                                                   |
+| `Alert`         | `onHide`        | `onClose`         | Callback for dismissing                                     |
+| `Button`        | `label`         | `children`        | `<Button label="X">` → `<IressButton>X</IressButton>`       |
+| `Button`        | `mode`          | `mode`            | Unchanged; values slightly different                        |
+| `Button`        | `labelHidden`   | `icon` prop       | Use `icon` prop for icon-only buttons                       |
+| `Button`        | `iconName`      | `icon`            | Use Material Symbol name                                    |
+| `Button`        | `showLoading`   | `loading`         | —                                                           |
+| `Modal`         | `onHide`        | `onShowChange`    | `(show: boolean) => void`                                   |
+| `Modal`         | `show`          | `show`            | Unchanged                                                   |
+| `Modal`         | `size`          | `size`            | Values: `sm`, `md`, `lg` (OUI had `xs`, `xl` too)           |
+| `Modal`         | `fixedFooter`   | `fixedFooter`     | Unchanged                                                   |
+| `Slideout`      | `show`          | `show`            | Unchanged                                                   |
+| `Slideout`      | `position`      | `position`        | Unchanged                                                   |
+| `Slideout`      | `size`          | `size`            | Values: `sm`, `md` (OUI had `lg`, `dynamic` too)            |
+| `Fieldset`      | `legend`        | `label`           | On `IressFieldGroup`                                        |
+| `Fieldset`      | `legendHidden`  | `hiddenLabel`     | —                                                           |
+| `RadioGroup`    | `legend`        | removed           | Use `IressFormField` `label` prop instead                   |
+| `RadioGroup`    | `legendHidden`  | removed           | Use `IressFormField` `hiddenLabel` prop                     |
+| `RadioGroup`    | `options`       | `children`        | Use `<IressRadio>` children instead of options array        |
+| `RadioGroup`    | `checked`       | `value`           | —                                                           |
+| `RadioGroup`    | `readOnly`      | `readOnly`        | Unchanged                                                   |
+| `Toggle`        | `legend`        | `children`        | —                                                           |
+| `Toggle`        | `legendHidden`  | `hiddenLabel`     | —                                                           |
+| `Toggle`        | `toggled`       | `checked`         | —                                                           |
+| `Toggle`        | `labelTrue`     | removed           | v6 Toggle is binary switch, no true/false labels            |
+| `Toggle`        | `labelFalse`    | removed           | v6 Toggle is binary switch, no true/false labels            |
+| `Label`         | `label`         | `children`        | `<Label label="X">` → `<IressLabel>X</IressLabel>`          |
+| `Label`         | `labelHidden`   | `hiddenLabel`     | —                                                           |
+| `Label`         | `optional`      | `required`        | Logic inverted                                              |
+| `Label`         | `required`      | `required`        | Now takes boolean, not string                               |
+| `Input`         | `inputRef`      | `ref`             | Use standard React ref                                      |
+| `Input`         | `type`          | `type`            | Unchanged                                                   |
+| `Checkbox`      | `label`         | `children`        | —                                                           |
+| `Checkbox`      | `labelHidden`   | `hiddenLabel`     | —                                                           |
+| `Checkbox`      | `isInline`      | removed           | Use parent layout component                                 |
+| `Slider`        | `label`         | removed           | Use `aria-label` or wrap in `IressFormField`                |
+| `Slider`        | `hideCurrentLabel` | `hiddenValueTooltip` | —                                                      |
+| `Slider`        | `hideBoundaryLabels` | `tickLabels`  | Set to `false` to hide                                      |
+| `Tabs`          | `activeTabIndex`| `selected`        | Use tab `value` prop to identify tabs                       |
+| `Tabs`          | `onSelect`      | `onChange`        | —                                                           |
+| `Tabs`          | `lazy`          | removed           | v6 tabs are always lazy                                     |
+| `ProgressBar`   | `now`           | `value`           | —                                                           |
+| `ProgressBar`   | `color`         | removed           | Use CSS custom properties for color                         |
+| `ProgressBar`   | `striped`       | removed           | Not available in v6                                         |
+| `ProgressBar`   | `animated`      | removed           | Not available in v6                                         |
+
+## IDS v4 React → IDS v6 React Prop Changes (Verified against v4 source)
+
+The v4 React wrappers (`@iress/components-react`) automatically convert Stencil's kebab-case props to camelCase and map custom events to React callback props (e.g., `iressModalEntered` → `onEntered`). This section documents the v4 React API compared to v6.
+
+### Button
+
+| v4 React prop          | v6 React prop           | Notes                                                       |
+| ---------------------- | ----------------------- | ----------------------------------------------------------- |
+| `mode`                 | `mode`                  | v4 values: `primary`, `secondary`, `tertiary`, `link`, `danger`, `positive`, `negative` → v6: `primary`, `secondary`, `tertiary`, `quaternary`, `muted` |
+| `mode="link"`          | removed                 | Use `mode="tertiary"` or `IressLink` component              |
+| `mode="danger"`        | `status="danger"`       | Use `status` prop with any mode                             |
+| `mode="positive"`      | `status="success"`      | Use `status` prop with any mode                             |
+| `mode="negative"`      | removed                 | Use `status="danger"` instead                               |
+| `loading`              | `loading`               | Unchanged                                                   |
+| `loadingText`          | `loading` (string)      | v6 accepts boolean or string for loading                    |
+| `fluid`                | `fluid`                 | Unchanged                                                   |
+| `noWrap`               | `noWrap`                | Unchanged                                                   |
+| `href`                 | `href`                  | Unchanged                                                   |
+| `onClick`              | `onClick`               | Unchanged                                                   |
+| slot `icon-only`       | `icon` prop             | v6 uses `icon` prop for icon-only buttons                   |
+| slot `prepend`         | `prepend` prop          | v6 uses prop instead of slot                                |
+| slot `append`          | `append` prop           | v6 uses prop instead of slot                                |
+
+### Alert
+
+| v4 React prop          | v6 React prop           | Notes                                                       |
+| ---------------------- | ----------------------- | ----------------------------------------------------------- |
+| `status`               | `status`                | v4: `error`, `warning`, `success`, `info` → v6: `danger`, `warning`, `success`, `info`, `neutral` |
+| `status="error"`       | `status="danger"`       | Value renamed                                               |
+| `headingText`          | `heading`               | Prop renamed                                                |
+| `headingLevel`         | removed                 | v6 auto-handles heading level                               |
+| slot `footer`          | `actions` prop          | v6 uses `actions` array for buttons                         |
+
+### Modal
+
+| v4 React prop          | v6 React prop           | Notes                                                       |
+| ---------------------- | ----------------------- | ----------------------------------------------------------- |
+| `show`                 | `show`                  | Unchanged                                                   |
+| `size`                 | `size`                  | v4 allowed responsive array → v6 single value only          |
+| `closeText`            | `closeText`             | Unchanged                                                   |
+| `fixedFooter`          | `fixedFooter`           | Unchanged                                                   |
+| `disableBackdropClick` | `disableBackdropClick`  | Unchanged                                                   |
+| `noCloseButton`        | `noCloseButton`         | Unchanged                                                   |
+| `padding`              | `p` (styling prop)      | Use styling prop instead                                    |
+| `onEntered`            | `onEntered`             | Unchanged                                                   |
+| `onExited`             | `onExited`              | Unchanged                                                   |
+| slot `footer`          | `footer` prop           | v6 uses prop instead of slot                                |
+
+### Slideout
+
+| v4 React prop          | v6 React prop           | Notes                                                       |
+| ---------------------- | ----------------------- | ----------------------------------------------------------- |
+| `show`                 | `show`                  | Unchanged                                                   |
+| `eleToPush`            | `eleToPush`             | Unchanged                                                   |
+| `mode`                 | `mode`                  | Unchanged (`overlay`, `push`)                               |
+| `closeText`            | `closeText`             | Unchanged                                                   |
+| `padding`              | removed                 | Use `p` styling prop on content                             |
+| `position`             | `position`              | Unchanged                                                   |
+| `size`                 | `size`                  | Unchanged                                                   |
+| `backdrop`             | removed                 | v6 always has backdrop in overlay mode                      |
+| `onEntered`            | `onEntered`             | Unchanged                                                   |
+| `onExited`             | `onExited`              | Unchanged                                                   |
+| slot `footer`          | `footer` prop           | v6 uses prop instead of slot                                |
+
+### Panel
+
+| v4 React prop          | v6 React prop           | Notes                                                       |
+| ---------------------- | ----------------------- | ----------------------------------------------------------- |
+| `background`           | `bg`                    | v4: `default`, `alt`, `transparent` → v6: `alt`, token values |
+| `padding`              | `p` (styling prop)      | Use styling prop instead                                    |
+| `textAlign`            | `textAlign`             | Unchanged                                                   |
+| `stretch`              | `stretch`               | Unchanged (now styling prop)                                |
+| `noBorderRadius`       | `borderRadius="none"`   | Use `borderRadius` prop instead                             |
+
+### Text
+
+| v4 React prop          | v6 React prop           | Notes                                                       |
+| ---------------------- | ----------------------- | ----------------------------------------------------------- |
+| `variant`              | `textStyle`             | Prop renamed                                                |
+| `mode`                 | `color`                 | Prop renamed                                                |
+| `align`                | `textAlign`             | Prop renamed                                                |
+| `element`              | `element`               | Unchanged                                                   |
+| `noGutter`             | removed                 | Use `mb="none"` styling prop                                |
+
+### Stack / Inline
+
+| v4 React prop          | v6 React prop           | Notes                                                       |
+| ---------------------- | ----------------------- | ----------------------------------------------------------- |
+| `gutter`               | `gap`                   | v4: `none`, `xs`, `sm`, `md`, `lg`, `xl` → v6 spacing tokens |
+| `horizontalAlign`      | `justify`               | Prop renamed (Inline only)                                  |
+| `verticalAlign`        | `align`                 | Prop renamed (Inline only)                                  |
+| `noWrap`               | `noWrap`                | Unchanged                                                   |
+
+### Icon
+
+| v4 React prop          | v6 React prop           | Notes                                                       |
+| ---------------------- | ----------------------- | ----------------------------------------------------------- |
+| `name`                 | `name`                  | v4: FontAwesome names → v6: Material Symbols                |
+| `set`                  | removed                 | v6 uses Material Symbols only                               |
+| `mode`                 | `color`                 | Prop renamed                                                |
+| `size`                 | removed                 | Inherits font size from parent                              |
+| `fixedWidth`           | removed                 | Not needed with Material Symbols                            |
+| `spin`                 | removed                 | Use CSS animation instead                                   |
+| `rotate`               | removed                 | Use CSS transform instead                                   |
+| `flip`                 | removed                 | Use CSS transform instead                                   |
+| `screenreaderText`     | `screenreaderText`      | Unchanged                                                   |
+
+### Label
+
+| v4 React prop          | v6 React prop           | Notes                                                       |
+| ---------------------- | ----------------------- | ----------------------------------------------------------- |
+| `labelText`            | `children`              | v4 uses prop → v6 uses children                             |
+| `for`                  | `htmlFor`               | Prop renamed                                                |
+| `hiddenLabel`          | `hiddenLabel`           | Unchanged                                                   |
+| `optional`             | `required` (inverted)   | Logic inverted                                              |
+| `optionalText`         | removed                 | v6 doesn't show "(optional)" text                           |
+| `focusOn`              | removed                 | Not needed in v6                                            |
+
+### Field
+
+| v4 React prop          | v6 React prop           | Notes                                                       |
+| ---------------------- | ----------------------- | ----------------------------------------------------------- |
+| `label`                | `label`                 | Unchanged                                                   |
+| `hiddenLabel`          | `hiddenLabel`           | Unchanged                                                   |
+| `hint`                 | `hint`                  | Unchanged                                                   |
+| `error`                | `errorMessages`         | Now takes array of `ValidationMessageObj`                   |
+| `disabledValidation`   | removed                 | Validation handled by `IressFormField` rules                |
+| `inline`               | `horizontal`            | Prop renamed                                                |
+| `optionalText`         | removed                 | —                                                           |
+| `valueMissing`         | `rules.required`        | Use `rules` prop on `IressFormField`                        |
+| `tooLong`              | `rules.maxLength`       | Use `rules` prop on `IressFormField`                        |
+| `tooShort`             | `rules.minLength`       | Use `rules` prop on `IressFormField`                        |
+| `patternMismatch`      | `rules.pattern`         | Use `rules` prop on `IressFormField`                        |
+| `rangeOverflow`        | `rules.max`             | Use `rules` prop on `IressFormField`                        |
+| `rangeUnderflow`       | `rules.min`             | Use `rules` prop on `IressFormField`                        |
+
+### Toggle
+
+| v4 React prop          | v6 React prop           | Notes                                                       |
+| ---------------------- | ----------------------- | ----------------------------------------------------------- |
+| `checked`              | `checked`               | Unchanged                                                   |
+| `label`                | `children`              | v4 uses prop → v6 uses children                             |
+| `hiddenLabel`          | `hiddenLabel`           | Unchanged                                                   |
+| `layout`               | `layout`                | Unchanged                                                   |
+| `onChange`             | `onChange`              | Unchanged (signature slightly different)                    |
+
+### Badge → Pill
+
+| v4 React prop          | v6 React prop           | Notes                                                       |
+| ---------------------- | ----------------------- | ----------------------------------------------------------- |
+| Component renamed      | `IressPill`             | `IressBadge` → `IressPill`                                  |
+| `mode`                 | `status`                | Prop renamed                                                |
+| `pill`                 | removed                 | v6 Pill is always pill-shaped                               |
+| slot `host`            | removed                 | Use composition instead                                     |
+
+### SkipLink
+
+| v4 React prop          | v6 React prop           | Notes                                                       |
+| ---------------------- | ----------------------- | ----------------------------------------------------------- |
+| `targetId`             | `href`                  | Now takes full href with `#` (e.g., `href="#main"`)         |
+| `text`                 | `children`              | v4 uses prop → v6 uses children                             |
+| `customRoute`          | `element` prop          | Use `element` to customize rendered element                 |
+
+### Expander
+
+| v4 React prop          | v6 React prop           | Notes                                                       |
+| ---------------------- | ----------------------- | ----------------------------------------------------------- |
+| `open`                 | `open`                  | Unchanged                                                   |
+| `mode`                 | `mode`                  | v4: `section`, `heading`, `link` → v6: `section` only       |
+| `mode="heading"`       | `mode="section"`        | Value renamed                                               |
+| slot `activator`       | `activator` prop        | v4 uses slot → v6 uses prop                                 |
+| `onChange`             | `onChange`              | Unchanged                                                   |
+
+### Tabs (TabContainer → TabSet)
+
+| v4 React prop          | v6 React prop           | Notes                                                       |
+| ---------------------- | ----------------------- | ----------------------------------------------------------- |
+| Component renamed      | `IressTabSet`           | `IressTabContainer` → `IressTabSet`                         |
+| `onChange`             | `onChange`              | Unchanged                                                   |
+| `IressTabButton`       | `IressTab`              | Component renamed                                           |
+| `IressTabPanel`        | removed                 | Content now passed as `IressTab` children                   |
+
+
+## Key Architecture Changes (v4 React → v6 React)
+
+### Package Changes
+
+| v4 Package                      | v6 Package                      | Notes                                                       |
+| ------------------------------- | ------------------------------- | ----------------------------------------------------------- |
+| `@iress/components-react`       | `@iress-oss/ids-components`     | Main component package                                      |
+| `@iress/ids-react-test-utils`   | `@testing-library/react`        | Use standard RTL                                            |
+| `@iress/components` (CSS)       | `@iress-oss/ids-components/dist/style.css` | CSS import path changed                          |
+| `@iress/ids-themes`             | `@iress-oss/ids-tokens`         | Design tokens package                                       |
+
+### Slot → Prop Migration
+
+v4 React wrappers used slots (via `slot` prop on children). v6 uses props directly.
+
+```tsx
+// ❌ v4: Using slots
+<IressButton>
+  <IressIcon slot="prepend" name="search" />
+  Search
+</IressButton>
+
+// ✅ v6: Using props
+<IressButton prepend={<IressIcon name="search" />}>
+  Search
+</IressButton>
+```
+
+```tsx
+// ❌ v4: Modal footer slot
+<IressModal show={show}>
+  Content
+  <div slot="footer">
+    <IressButton>Close</IressButton>
+  </div>
+</IressModal>
+
+// ✅ v6: Modal footer prop
+<IressModal 
+  show={show} 
+  footer={<IressButton>Close</IressButton>}
+>
+  Content
+</IressModal>
+```
+
+### Event Callback Changes
+
+v4 React wrappers mapped Stencil custom events to React callback props. Most remain the same in v6, but some have changed:
+
+| v4 Callback             | v6 Callback             | Notes                                                       |
+| ----------------------- | ----------------------- | ----------------------------------------------------------- |
+| `onClick`               | `onClick`               | Unchanged                                                   |
+| `onChange`              | `onChange`              | Unchanged (signature may differ)                            |
+| `onBlur`                | `onBlur`                | Unchanged                                                   |
+| `onFocus`               | `onFocus`               | Unchanged                                                   |
+| `onEntered`             | `onEntered`             | Unchanged                                                   |
+| `onExited`              | `onExited`              | Unchanged                                                   |
+| `onActivated`           | `onActivated`           | Unchanged                                                   |
+| `onDeactivated`         | `onDeactivated`         | Unchanged                                                   |
+| `onClear`               | `onClear`               | Unchanged                                                   |
+
+### Test Utility Migration
+
+v4 provided `@iress/ids-react-test-utils` with `idsFireEvent` for testing custom events. v6 uses standard React Testing Library.
+
+```tsx
+// ❌ v4: Using idsFireEvent
+import { idsFireEvent } from '@iress/ids-react-test-utils';
+
+idsFireEvent.change(input, { target: { value: 'test' } });
+idsFireEvent.entered(modal);
+idsFireEvent.blur(field, { target: { value: 'test' } });
+
+// ✅ v6: Using standard RTL
+import { fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+await userEvent.type(input, 'test');
+fireEvent.transitionEnd(modal); // or wait for onEntered callback
+await userEvent.tab(); // for blur
+```
+
+### Helper Function Migration
+
+v4 provided helper functions in `@iress/components-react`. These are no longer needed in v6.
+
+| v4 Helper                       | v6 Replacement                  |
+| ------------------------------- | ------------------------------- |
+| `mapCheckboxGroupOptions()`     | Use `<IressCheckbox>` children directly |
+| `mapRadioGroupOptions()`        | Use `<IressRadio>` children directly |
+| `mapSelectOptions()`            | Use `options` prop on `IressSelect` |
+| `mapTabs()`                     | Use `<IressTab>` children directly |
+| `mapMenuItems()`                | Use `<IressMenuItem>` children directly |
+| `showModal(id)`                 | Use `show` prop or `useModal` hook |
+| `showSlideout(id)`              | Use `show` prop or `useSlideout` hook |
+| `rowData(arr, ref)`             | Pass `rowData` prop directly to `IressTable` |

--- a/.agents/skills/version-migration/references/testing-migration.md
+++ b/.agents/skills/version-migration/references/testing-migration.md
@@ -2,28 +2,93 @@
 
 IDS v6 uses standard React Testing Library — no special test utilities needed.
 
-## Remove IDS v4 test utilities
+## Remove IDS v4 React test utilities
+
+v4 provided `@iress/ids-react-test-utils` with custom helpers for testing Stencil web component wrappers. These are no longer needed in v6.
 
 ```ts
-// ❌ Remove
-import {
-  idsFireEvent,
+// ❌ Remove v4 test utils
+import { 
+  idsFireEvent, 
   mockLazyLoadedComponents,
-} from '@iress/components-react/test';
+  componentLoad 
+} from '@iress/ids-react-test-utils';
 
 // ✅ Use standard RTL
-import { render, fireEvent, screen } from '@testing-library/react';
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+```
+
+## idsFireEvent Migration
+
+v4's `idsFireEvent` was needed to fire custom Stencil events. v6 uses standard React events.
+
+| v4 `idsFireEvent` method             | v6 Replacement                                       |
+| ------------------------------------ | ---------------------------------------------------- |
+| `idsFireEvent.click(el)`             | `await userEvent.click(el)`                          |
+| `idsFireEvent.change(el, { target: { value } })` | `await userEvent.type(el, value)` or `fireEvent.change(el, { target: { value } })` |
+| `idsFireEvent.blur(el)`              | `await userEvent.tab()` or `fireEvent.blur(el)`      |
+| `idsFireEvent.focus(el)`             | `await userEvent.click(el)` or `fireEvent.focus(el)` |
+| `idsFireEvent.entered(modal)`        | Wait for `onEntered` callback or use `waitFor`       |
+| `idsFireEvent.exited(modal)`         | Wait for `onExited` callback or use `waitFor`        |
+| `idsFireEvent.select(el, detail)`    | Use `onChange` callback testing                      |
+| `idsFireEvent.submit(form, data)`    | `await userEvent.click(submitButton)`                |
+| `idsFireEvent.error(form, messages)` | Test validation via form submission                  |
+
+### Before/After Examples
+
+```tsx
+// ❌ v4: Testing modal entered
+import { idsFireEvent } from '@iress/ids-react-test-utils';
+
+const onEntered = jest.fn();
+render(<IressModal show onEntered={onEntered} />);
+const modal = screen.getByRole('dialog');
+idsFireEvent.entered(modal);
+expect(onEntered).toHaveBeenCalled();
+
+// ✅ v6: Testing modal entered
+const onEntered = jest.fn();
+render(<IressModal show onEntered={onEntered} />);
+await waitFor(() => expect(onEntered).toHaveBeenCalled());
+```
+
+```tsx
+// ❌ v4: Testing input change
+import { idsFireEvent } from '@iress/ids-react-test-utils';
+
+idsFireEvent.change(input, { target: { value: 'test' } });
+
+// ✅ v6: Testing input change
+await userEvent.type(input, 'test');
+// or
+fireEvent.change(input, { target: { value: 'test' } });
+```
+
+## Remove mockLazyLoadedComponents
+
+v4 required mocking lazy-loaded Stencil components. v6 components load synchronously.
+
+```ts
+// ❌ v4: Required for async component loading
+import { mockLazyLoadedComponents } from '@iress/ids-react-test-utils';
+
+beforeEach(() => {
+  mockLazyLoadedComponents();
+});
+
+// ✅ v6: Not needed — remove entirely
 ```
 
 ## Test pattern changes
 
-| Old pattern                          | New pattern                                          |
+| v4 pattern                           | v6 pattern                                           |
 | ------------------------------------ | ---------------------------------------------------- |
-| `idsFireEvent.click(el)`             | `fireEvent.click(el)` or `await userEvent.click(el)` |
+| `idsFireEvent.click(el)`             | `await userEvent.click(el)`                          |
 | `await findByTestId('x__button')`    | `getByRole('button', { name: 'X' })`                 |
 | `mockLazyLoadedComponents()`         | Remove — components load synchronously               |
 | Async `findBy*` for component render | Synchronous `getBy*` in most cases                   |
+| `componentLoad()`                    | Remove — not needed                                  |
 
 ## Prefer accessibility queries
 
@@ -50,19 +115,24 @@ transformIgnorePatterns: [
 ## Form test migration
 
 ```tsx
-// ❌ Old: Formik-based test
-const { getByLabelText } = render(
-  <Formik initialValues={{ name: '' }} onSubmit={mockSubmit}>
-    {() => (
-      <Form>
-        <Field name="name" as={Input} />
-      </Form>
-    )}
-  </Formik>,
+// ❌ v4: Testing with IressForm and idsFireEvent
+import { idsFireEvent } from '@iress/ids-react-test-utils';
+
+render(
+  <IressForm onSubmit={mockSubmit}>
+    <IressField label="Name">
+      <IressInput name="name" />
+    </IressField>
+    <IressButton type="submit">Submit</IressButton>
+  </IressForm>
 );
 
-// ✅ New: IDS v6 form test
-const { getByRole } = render(
+const input = screen.getByLabelText('Name');
+idsFireEvent.change(input, { target: { value: 'Test' } });
+idsFireEvent.submit(form, { name: 'Test' });
+
+// ✅ v6: Testing with IressForm and userEvent
+render(
   <IressForm defaultValues={{ name: '' }} onSubmit={mockSubmit}>
     <IressFormField
       name="name"
@@ -73,7 +143,7 @@ const { getByRole } = render(
   </IressForm>,
 );
 
-await userEvent.type(getByRole('textbox', { name: 'Name' }), 'Test');
-await userEvent.click(getByRole('button', { name: 'Submit' }));
+await userEvent.type(screen.getByRole('textbox', { name: 'Name' }), 'Test');
+await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
 expect(mockSubmit).toHaveBeenCalledWith({ name: 'Test' });
 ```

--- a/.agents/skills/version-migration/references/v5-to-v6-migration.md
+++ b/.agents/skills/version-migration/references/v5-to-v6-migration.md
@@ -1,0 +1,219 @@
+# IDS v5 → v6 Migration Reference
+
+This document covers changes specific to migrating from IDS v5 (`@iress-oss/ids-components@5.x`) to v6.
+
+## Package Changes
+
+| v5 Package                      | v6 Package                      |
+| ------------------------------- | ------------------------------- |
+| `@iress-oss/ids-components`     | `@iress-oss/ids-components`     |
+| CSS: `dist/style.css`           | CSS: `styled-system/styles.css` |
+
+## Component Renames
+
+| v5 Component         | v6 Component                   | Notes                                                                |
+| -------------------- | ------------------------------ | -------------------------------------------------------------------- |
+| `IressBadge`         | `IressPill`                    | Renamed                                                              |
+| `IressFilter`        | `IressDropdownMenu`            | Now a pattern component                                              |
+| `IressRichSelect`    | `IressSelect`                  | Consolidated; v5 `IressSelect` replaced by `native` prop on v6 Select |
+| `IressCombobox`      | `IressSelect` or `IressAutocomplete` | Was deprecated in v5                                           |
+| `IressMultiCombobox` | `IressSelect` with `multiSelect` | Was deprecated in v5                                              |
+| `IressNavbar`        | Removed                        | Build custom navigation per-application                              |
+
+## New Components in v6
+
+| Component                    | Purpose                                    |
+| ---------------------------- | ------------------------------------------ |
+| `IressBreadcrumbs`           | Navigation hierarchy                       |
+| `IressContextualMenu`        | Context / "more actions" menu              |
+| `IressDropdownMenu`          | Filter/navigation dropdown                 |
+| `IressLink`                  | Anchor links in text                       |
+| `IressPill`                  | Status indicators, counters                |
+| `IressImage`                 | Responsive images                          |
+| `IressMenuGroup`             | Menu item grouping                         |
+| `IressShadow`                | Shadow DOM wrapper for micro-frontends     |
+| `IressSideNav`               | Side navigation                            |
+| `IressFormField`             | Form-integrated field with validation      |
+| `IressFormValidationSummary` | Form validation summary                    |
+
+## Prop Changes by Component
+
+### Button
+
+| v5 prop              | v6 prop               | Notes                                                       |
+| -------------------- | --------------------- | ----------------------------------------------------------- |
+| `mode="link"`        | `mode="tertiary"`     | Or use `IressLink` for links in text                        |
+| `mode="danger"`      | `status="danger"`     | Use `status` prop with any mode                             |
+| `mode="positive"`    | `status="success"`    | Use `status` prop with any mode                             |
+| `mode="negative"`    | `status="danger"`     | Use `status` prop                                           |
+| `attrs`              | removed               | Use native HTML attributes directly                         |
+| —                    | `icon`                | New: Material Symbol name for icon-only buttons             |
+| —                    | `compact`             | New: reduces padding for compact buttons                    |
+| —                    | `status`              | New: `success` or `danger`                                  |
+| —                    | `active`              | New: indicates button has activated a modal/popover         |
+
+### Alert
+
+| v5 prop              | v6 prop               | Notes                                                       |
+| -------------------- | --------------------- | ----------------------------------------------------------- |
+| `status`             | `status`              | Added `neutral` option in v6                                |
+| `headingText`        | `heading`             | `headingText` was deprecated in v5                          |
+| `headingLevel`       | removed               | Was deprecated in v5; v6 auto-handles                       |
+| `footer`             | `footer`              | Unchanged                                                   |
+| —                    | `actions`             | New: array of button props with opinionated styling         |
+| —                    | `closed`              | New: controlled dismissal                                   |
+| —                    | `defaultClosed`       | New: uncontrolled dismissal                                 |
+| —                    | `onClose`             | New: callback when dismissed                                |
+| —                    | `icon`                | New: custom icon or `false` to hide                         |
+| —                    | `multiLine`           | New: layout for longer content                              |
+| —                    | `variant`             | New: `sidebar` or `full-width`                              |
+
+### Toggle
+
+| v5 prop              | v6 prop               | Notes                                                       |
+| -------------------- | --------------------- | ----------------------------------------------------------- |
+| `checked`            | `checked`             | Unchanged (controlled mode)                                 |
+| —                    | `defaultChecked`      | New: for uncontrolled mode                                  |
+| `children`           | `children`            | Unchanged                                                   |
+| `hiddenLabel`        | `hiddenLabel`         | Unchanged                                                   |
+| `layout`             | `layout`              | Unchanged                                                   |
+| `onChange`           | `onChange`            | Unchanged                                                   |
+| —                    | `disabled`            | New: disables the toggle                                    |
+
+### Field (IressField)
+
+| v5 prop              | v6 prop               | Notes                                                       |
+| -------------------- | --------------------- | ----------------------------------------------------------- |
+| `label`              | `label`               | Unchanged                                                   |
+| `hiddenLabel`        | `hiddenLabel`         | Unchanged                                                   |
+| `hint`               | `hint`                | Unchanged                                                   |
+| `error`              | `error`               | Unchanged                                                   |
+| `errorMessages`      | `errorMessages`       | Unchanged                                                   |
+| `optional`           | removed               | Use `required={false}` instead                              |
+| `required`           | `required`            | Unchanged                                                   |
+| `readOnly`           | `readOnly`            | Unchanged                                                   |
+| `htmlFor`            | `htmlFor`             | Unchanged                                                   |
+| —                    | `horizontal`          | New: inline label/input layout                              |
+| —                    | `labelWidth`          | New: label width in horizontal mode                         |
+| —                    | `removeErrorMargin`   | New: removes reserved error space                           |
+| —                    | `supplementary`       | New: content below field when no error                      |
+
+### Modal
+
+| v5 prop              | v6 prop               | Notes                                                       |
+| -------------------- | --------------------- | ----------------------------------------------------------- |
+| `show`               | `show`                | Unchanged                                                   |
+| `defaultShow`        | `defaultShow`         | Unchanged                                                   |
+| `size`               | `size`                | Unchanged                                                   |
+| `heading`            | `heading`             | Unchanged                                                   |
+| `footer`             | `footer`              | Unchanged                                                   |
+| `padding`            | `p` (styling prop)    | Use styling prop instead                                    |
+| `onShowChange`       | `onShowChange`        | Unchanged                                                   |
+| `onEntered`          | `onEntered`           | Unchanged                                                   |
+| `onExited`           | `onExited`            | Unchanged                                                   |
+
+### Badge → Pill
+
+| v5 prop              | v6 prop               | Notes                                                       |
+| -------------------- | --------------------- | ----------------------------------------------------------- |
+| Component            | `IressPill`           | `IressBadge` renamed to `IressPill`                         |
+| `mode`               | `mode`                | Values changed: now uses data palette (10-90) or status     |
+| `pill`               | removed               | v6 Pill is always pill-shaped                               |
+| `host`               | removed               | Use composition instead                                     |
+
+### Select (was RichSelect)
+
+| v5 prop              | v6 prop               | Notes                                                       |
+| -------------------- | --------------------- | ----------------------------------------------------------- |
+| Component            | `IressSelect`         | `IressRichSelect` renamed to `IressSelect`                  |
+| `options`            | `options`             | Unchanged                                                   |
+| `value`              | `value`               | Unchanged                                                   |
+| `multiSelect`        | `multiSelect`         | Unchanged                                                   |
+| —                    | `native`              | New: renders native `<select>` element                      |
+
+### Filter → DropdownMenu
+
+| v5 prop              | v6 prop               | Notes                                                       |
+| -------------------- | --------------------- | ----------------------------------------------------------- |
+| Component            | `IressDropdownMenu`   | `IressFilter` renamed                                       |
+| `options`            | `options`             | Unchanged                                                   |
+| `value`              | `selected`            | Prop renamed                                                |
+| `multiSelect`        | `multiSelect`         | Unchanged                                                   |
+| `searchable`         | `searchable`          | Unchanged                                                   |
+
+## Styling Changes
+
+### CSS Import
+
+```tsx
+// v5
+import '@iress-oss/ids-components/dist/style.css';
+
+// v6
+import '@iress-oss/ids-components/styled-system/styles.css';
+```
+
+### Styling Props
+
+v6 uses Panda CSS and exposes styling props on all components:
+
+```tsx
+// v6 styling props
+<IressPanel p="lg" m="xl" bg="alt" />
+
+// Responsive
+<IressPanel p={{ base: 'sm', xl: 'lg' }} />
+```
+
+### Design Tokens
+
+```tsx
+// v6 - type-safe cssVars
+import { cssVars } from '@iress-oss/ids-tokens';
+
+<div style={{ color: cssVars.colour.primary.text }} />
+```
+
+## Form Migration
+
+v5 used standalone form components. v6 introduces `IressForm` + `IressFormField` with React Hook Form integration.
+
+```tsx
+// v5
+<IressField label="Email" error={errors.email}>
+  <IressInput name="email" value={value} onChange={handleChange} />
+</IressField>
+
+// v6
+<IressForm defaultValues={{ email: '' }} onSubmit={handleSubmit}>
+  <IressFormField
+    name="email"
+    label="Email"
+    render={(field) => <IressInput {...field} />}
+    rules={{ required: 'Required' }}
+  />
+</IressForm>
+```
+
+Note: `IressField` still exists in v6 for standalone layout without form binding.
+
+## Icon Changes
+
+v5 used FontAwesome icons. v6 uses Material Symbols.
+
+```tsx
+// v5
+<IressIcon name="check" set="fas" />
+
+// v6
+<IressIcon name="check_circle" />
+```
+
+| v5 prop              | v6 prop               | Notes                                                       |
+| -------------------- | --------------------- | ----------------------------------------------------------- |
+| `name`               | `name`                | FontAwesome → Material Symbols names                        |
+| `set`                | removed               | v6 uses Material Symbols only                               |
+| `mode`               | `color`               | Prop renamed                                                |
+| `size`               | removed               | Inherits font size from parent                              |
+| `fixedWidth`         | removed               | Not needed with Material Symbols                            |
+| `spin`               | removed               | Use CSS animation                                           |

--- a/.agents/skills/version-migration/references/visual-regression-testing.md
+++ b/.agents/skills/version-migration/references/visual-regression-testing.md
@@ -1,0 +1,220 @@
+# Visual Regression Testing for Migration
+
+Visual regression testing (VRT) is highly recommended for IDS v6 migration to catch styling and layout changes that automated checks miss.
+
+## Why VRT for Migration?
+
+IDS v6 introduces significant styling changes:
+- New CSS architecture (Panda CSS)
+- Different default spacing/sizing
+- Icon system change (FontAwesome → Material Symbols)
+- Component visual updates (shadows, borders, colors)
+
+VRT catches these before users do.
+
+## Recommended: Playwright VRT
+
+Playwright has built-in visual comparison with minimal setup.
+
+### Automated Setup
+
+The migration skill includes a script that auto-detects your routing framework and generates tests:
+
+```bash
+.agents/skills/version-migration/scripts/setup-playwright-vrt.sh
+```
+
+This script:
+- Detects **React Router** or **Next.js** (App Router / Pages Router)
+- Finds all static routes in your application
+- Generates Playwright config and test suite
+- Creates tests for each route + interactive components
+- Includes responsive viewport tests
+
+**Supported frameworks:**
+- React Router (v5, v6)
+- Next.js App Router
+- Next.js Pages Router
+
+Dynamic routes (with `:param` or `[param]`) are skipped automatically.
+
+### Manual Setup
+
+If you prefer manual setup or use a different router:
+
+```bash
+# Install Playwright
+npm install -D @playwright/test
+
+# Initialize (creates playwright.config.ts)
+npx playwright install
+```
+
+### Basic Configuration
+
+```typescript
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  use: {
+    baseURL: 'http://localhost:3000',
+    screenshot: 'only-on-failure',
+  },
+  // Generate baseline screenshots
+  updateSnapshots: process.env.UPDATE_SNAPSHOTS === 'true' ? 'all' : 'none',
+});
+```
+
+### Pre-Migration: Capture Baselines
+
+Before migrating, the setup script has already generated route-based tests. Just capture baselines:
+
+```typescript
+// e2e/components.spec.ts
+import { test, expect } from '@playwright/test';
+
+test('button variants', async ({ page }) => {
+  await page.goto('/components/button');
+  await expect(page).toHaveScreenshot('button-variants.png');
+});
+
+test('form validation', async ({ page }) => {
+  await page.goto('/forms/example');
+  await page.getByRole('button', { name: 'Submit' }).click();
+  await expect(page).toHaveScreenshot('form-validation.png');
+});
+
+test('modal open', async ({ page }) => {
+  await page.goto('/components/modal');
+  await page.getByRole('button', { name: 'Open Modal' }).click();
+  await page.waitForSelector('[role="dialog"]');
+  await expect(page).toHaveScreenshot('modal-open.png');
+});
+```
+
+```bash
+UPDATE_SNAPSHOTS=true npx playwright test
+```
+
+This creates `e2e/components.spec.ts-snapshots/` with baseline images for all detected routes.
+
+If you need to add custom tests, edit `e2e/components.spec.ts`:
+
+### Post-Migration: Compare
+
+After migrating to v6, run tests without `UPDATE_SNAPSHOTS`:
+
+```bash
+npx playwright test
+```
+
+Playwright will:
+- Compare new screenshots to baselines
+- Fail tests if differences exceed threshold
+- Generate diff images showing changes
+
+### Review Differences
+
+```bash
+# Open HTML report with visual diffs
+npx playwright show-report
+```
+
+Review each diff:
+- ✅ **Expected changes**: Update baseline (`UPDATE_SNAPSHOTS=true`)
+- ❌ **Regressions**: Fix the component/styling
+
+## Alternative: Chromatic (Storybook)
+
+If using Storybook, Chromatic provides automated VRT:
+
+```bash
+# Install
+npm install -D chromatic
+
+# Capture baseline (before migration)
+npx chromatic --project-token=<token>
+
+# After migration, run again
+npx chromatic --project-token=<token>
+```
+
+Chromatic shows visual diffs in a web UI.
+
+## What to Test
+
+The auto-generated test suite covers:
+
+1. **All static routes**: Every page in your app (excluding dynamic routes)
+2. **Interactive components**: Buttons, forms, modals (auto-detected)
+3. **Responsive layouts**: Mobile, tablet, desktop viewports
+
+Additional priority components to add manually:
+
+1. **Forms**: Inputs, validation states, error messages
+2. **Modals/Slideouts**: Overlays, positioning, backdrop
+3. **Buttons**: All modes, loading states, icons
+4. **Alerts**: All status variants
+5. **Tables**: Headers, rows, sorting indicators
+6. **Navigation**: Menus, tabs, breadcrumbs
+7. **Layout**: Spacing, responsive breakpoints
+
+## Tips
+
+- **Test critical user flows**, not every component variation
+- **Use consistent viewport sizes** (e.g., 1280x720)
+- **Wait for animations** to complete before screenshots
+- **Mask dynamic content** (timestamps, random IDs)
+- **Set threshold** for acceptable pixel differences (e.g., 0.2%)
+
+## Playwright VRT Script
+
+Use `scripts/setup-playwright-vrt.sh` to generate a starter test suite based on your component usage.
+
+## Integration with CI
+
+```yaml
+# .github/workflows/vrt.yml
+name: Visual Regression Tests
+on: [pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+      - run: npm ci
+      - run: npx playwright install --with-deps
+      - run: npm run build
+      - run: npm start & npx wait-on http://localhost:3000
+      - run: npx playwright test
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+```
+
+## When to Update Baselines
+
+Update baselines when:
+- ✅ Visual change is intentional (design update)
+- ✅ Component behavior improved (better accessibility)
+- ✅ Layout fix (responsive improvement)
+
+Don't update when:
+- ❌ Unexpected spacing change
+- ❌ Missing styles
+- ❌ Broken layout
+- ❌ Wrong colors/icons
+
+## Post-Migration Checklist
+
+- [ ] Run VRT suite
+- [ ] Review all visual diffs
+- [ ] Fix regressions
+- [ ] Update baselines for intentional changes
+- [ ] Document visual changes in PR
+- [ ] Get design team approval for significant changes

--- a/.agents/skills/version-migration/scripts/README.md
+++ b/.agents/skills/version-migration/scripts/README.md
@@ -1,0 +1,85 @@
+# Migration Scripts
+
+Automated scripts to help with IDS v6 migration.
+
+## Usage
+
+Run from your project root (where `package.json` is located):
+
+```bash
+# 1. Detect current version and migration path
+.agents/skills/version-migration/scripts/detect-version.sh
+
+# 2. Audit component usage
+.agents/skills/version-migration/scripts/audit-components.sh
+
+# 3. Find deprecated props
+.agents/skills/version-migration/scripts/find-deprecated-props.sh
+
+# 4. Find Formik forms
+.agents/skills/version-migration/scripts/find-formik.sh
+
+# 5. Find old test utilities
+.agents/skills/version-migration/scripts/find-test-utils.sh
+
+# 6. Validate migration (run after migration)
+.agents/skills/version-migration/scripts/validate-migration.sh
+```
+
+## Scripts
+
+### `detect-version.sh`
+Detects current IDS/OUI version in package.json and recommends migration path.
+
+**Output**: Version detection, migration path, complexity estimate
+
+### `audit-components.sh`
+Scans codebase for IDS/OUI component usage and generates usage report.
+
+**Output**: Component usage counts, high-effort migration areas
+
+### `find-deprecated-props.sh`
+Searches for deprecated/renamed props that will break in v6.
+
+**Output**: List of deprecated props with file locations and replacement guidance
+
+### `find-formik.sh`
+Identifies Formik forms and Yup schemas needing migration to React Hook Form.
+
+**Output**: Formik file count, Yup schema count, migration scope
+
+### `find-test-utils.sh`
+Finds old IDS v4 test utilities (`idsFireEvent`, `mockLazyLoadedComponents`, etc.).
+
+**Output**: Old test patterns with file locations and replacement guidance
+
+### `validate-migration.sh`
+Runs post-migration validation checks.
+
+**Output**: Pass/fail report with errors and warnings
+
+**Exit codes**:
+- `0`: All checks passed (or warnings only)
+- `1`: Validation failed with errors
+
+### `setup-playwright-vrt.sh`
+Generates Playwright visual regression test suite for migration.
+
+**Output**: 
+- `playwright.config.ts` configuration
+- `e2e/components.spec.ts` test suite
+- Setup instructions
+
+**Usage**: Run before migration to set up VRT, then capture baselines
+
+## Requirements
+
+- Bash 4.0+
+- Standard Unix tools: `grep`, `wc`, `sed`
+- Run from project root directory
+
+## Notes
+
+- Scripts search the `src/` directory by default
+- All scripts are safe to run (read-only, no modifications)
+- False positives may occur — review results manually

--- a/.agents/skills/version-migration/scripts/audit-components.sh
+++ b/.agents/skills/version-migration/scripts/audit-components.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Audits IDS/OUI component usage across codebase
+
+set -euo pipefail
+
+echo "🔍 Auditing IDS/OUI component usage..."
+echo
+
+# Find all imports
+echo "📦 Scanning imports..."
+IMPORTS=$(grep -rh "from '@iress/oui'\|from \"@iress/oui\"\|from '@iress/components-react'\|from \"@iress/components-react\"\|from '@iress-oss/ids-components'\|from \"@iress-oss/ids-components\"" src/ 2>/dev/null | sort | uniq || true)
+
+if [[ -z "$IMPORTS" ]]; then
+  echo "ℹ️  No IDS/OUI imports found"
+  exit 0
+fi
+
+# Extract component names
+echo "📊 Component usage summary:"
+echo
+
+declare -A COMPONENTS
+
+while IFS= read -r line; do
+  # Extract components from import statements
+  COMPS=$(echo "$line" | sed -n 's/.*{\s*\([^}]*\)\s*}.*/\1/p' | tr ',' '\n')
+  
+  while IFS= read -r comp; do
+    comp=$(echo "$comp" | xargs) # trim whitespace
+    [[ -z "$comp" ]] && continue
+    
+    # Count occurrences in source files
+    COUNT=$(grep -r "\<$comp\>" src/ 2>/dev/null | grep -v "import" | wc -l || echo "0")
+    COMPONENTS["$comp"]=$COUNT
+  done <<< "$COMPS"
+done <<< "$IMPORTS"
+
+# Sort by usage count
+for comp in "${!COMPONENTS[@]}"; do
+  echo "${COMPONENTS[$comp]} $comp"
+done | sort -rn | while read -r count name; do
+  echo "  $name: $count usage(s)"
+done
+
+# Summary
+echo
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+TOTAL=${#COMPONENTS[@]}
+echo "📈 Total unique components: $TOTAL"
+
+# Check for high-effort components
+echo
+echo "⚠️  High-effort migrations:"
+FORMIK=$(grep -r "from 'formik'\|from \"formik\"" src/ 2>/dev/null | wc -l || echo "0")
+[[ $FORMIK -gt 0 ]] && echo "  • Forms with Formik: $FORMIK file(s) - requires React Hook Form migration"
+
+TEST_UTILS=$(grep -r "idsFireEvent\|mockLazyLoadedComponents" src/ 2>/dev/null | wc -l || echo "0")
+[[ $TEST_UTILS -gt 0 ]] && echo "  • Test files with old utils: $TEST_UTILS file(s)"
+
+CUSTOM_CSS=$(grep -r "\.oui-\|\.ids-\|iress-" src/ 2>/dev/null | grep -E "\.(css|scss|sass|less)" | wc -l || echo "0")
+[[ $CUSTOM_CSS -gt 0 ]] && echo "  • Files with custom CSS: $CUSTOM_CSS file(s) - may need styling prop migration"
+
+echo
+echo "💡 Next steps:"
+echo "  1. Run: scripts/find-deprecated-props.sh"
+echo "  2. Review: references/component-renames.md"
+echo "  3. Plan: Start with high-usage components"

--- a/.agents/skills/version-migration/scripts/detect-version.sh
+++ b/.agents/skills/version-migration/scripts/detect-version.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Detects current IDS/OUI version and recommends migration path
+
+set -euo pipefail
+
+echo "🔍 Detecting IDS/OUI version..."
+echo
+
+# Check for package.json
+if [[ ! -f "package.json" ]]; then
+  echo "❌ No package.json found in current directory"
+  exit 1
+fi
+
+# Detect versions
+OUI_VERSION=$(grep -o '"@iress/oui": "[^"]*"' package.json | grep -o '[0-9][^"]*' || echo "")
+V4_VERSION=$(grep -o '"@iress/components-react": "[^"]*"' package.json | grep -o '[0-9][^"]*' || echo "")
+V5_VERSION=$(grep -o '"@iress-oss/ids-components": "5\.[^"]*"' package.json | grep -o '[0-9][^"]*' || echo "")
+V6_VERSION=$(grep -o '"@iress-oss/ids-components": "6\.[^"]*"' package.json | grep -o '[0-9][^"]*' || echo "")
+
+# Report findings
+echo "📦 Detected packages:"
+[[ -n "$OUI_VERSION" ]] && echo "  • @iress/oui: $OUI_VERSION"
+[[ -n "$V4_VERSION" ]] && echo "  • @iress/components-react: $V4_VERSION (IDS v4)"
+[[ -n "$V5_VERSION" ]] && echo "  • @iress-oss/ids-components: $V5_VERSION (IDS v5)"
+[[ -n "$V6_VERSION" ]] && echo "  • @iress-oss/ids-components: $V6_VERSION (IDS v6)"
+
+if [[ -z "$OUI_VERSION" && -z "$V4_VERSION" && -z "$V5_VERSION" && -z "$V6_VERSION" ]]; then
+  echo "  ℹ️  No IDS/OUI packages detected"
+  exit 0
+fi
+
+echo
+echo "🗺️  Migration path:"
+
+# Determine migration path
+if [[ -n "$V6_VERSION" ]]; then
+  echo "  ✅ Already on IDS v6"
+elif [[ -n "$V5_VERSION" ]]; then
+  echo "  📍 IDS v5 → v6"
+  echo "  📖 Reference: references/v5-to-v6-migration.md"
+  echo "  🔧 Complexity: Low–Medium"
+elif [[ -n "$V4_VERSION" && -n "$OUI_VERSION" ]]; then
+  echo "  📍 OUI + IDS v4 → v6"
+  echo "  📖 Reference: references/prop-renames.md (both OUI and v4 sections)"
+  echo "  🔧 Complexity: High (form architecture change)"
+elif [[ -n "$V4_VERSION" ]]; then
+  echo "  📍 IDS v4 → v6"
+  echo "  📖 Reference: references/prop-renames.md (IDS v4 section)"
+  echo "  🔧 Complexity: Medium (form architecture change)"
+elif [[ -n "$OUI_VERSION" ]]; then
+  echo "  📍 OUI → v6"
+  echo "  📖 Reference: references/prop-renames.md (OUI section)"
+  echo "  🔧 Complexity: High (form architecture change)"
+fi
+
+echo
+echo "📚 Full guide: .agents/skills/version-migration/SKILL.md"

--- a/.agents/skills/version-migration/scripts/find-deprecated-props.sh
+++ b/.agents/skills/version-migration/scripts/find-deprecated-props.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Finds deprecated/renamed props that will break in IDS v6
+
+set -euo pipefail
+
+echo "🔍 Scanning for deprecated props..."
+echo
+
+FOUND=0
+
+# Define prop patterns to search for
+declare -A DEPRECATED_PROPS=(
+  ["variant="]="Renamed to 'mode' (Button) or 'status' (Alert)"
+  ["isOpen="]="Renamed to 'show' (Modal)"
+  ["onClose="]="Renamed to 'onShowChange' (Modal)"
+  ["gutter="]="Renamed to 'gap' (Stack/Inline)"
+  ["mode=\"link\""]="Removed - use mode=\"tertiary\" or IressLink"
+  ["mode='link'"]="Removed - use mode=\"tertiary\" or IressLink"
+  ["mode=\"danger\""]="Removed - use status=\"danger\""
+  ["mode='danger'"]="Removed - use status=\"danger\""
+  ["mode=\"positive\""]="Removed - use status=\"success\""
+  ["mode='positive'"]="Removed - use status=\"success\""
+  ["optional="]="Renamed to 'required' (inverted logic)"
+  ["legend="]="Renamed to 'label' (FieldGroup/RadioGroup)"
+  ["context="]="Renamed to 'status' (Alert - OUI)"
+  ["onHide="]="Renamed to 'onShowChange' (Modal - OUI)"
+  ["labelText="]="Use children instead (Label)"
+  ["headingText="]="Renamed to 'heading' (Alert)"
+  ["background="]="Renamed to 'bg' (Panel)"
+  ["targetId="]="Renamed to 'href' (SkipLink)"
+  ["textVariant="]="Renamed to 'textStyle' (Skeleton)"
+  ["align="]="Renamed to 'textAlign' (Text)"
+)
+
+# Search for each pattern
+for PATTERN in "${!DEPRECATED_PROPS[@]}"; do
+  RESULTS=$(grep -rn "$PATTERN" src/ 2>/dev/null | grep -v "node_modules" | grep -v ".test." | grep -v ".spec." || true)
+  
+  if [[ -n "$RESULTS" ]]; then
+    echo "❌ Found: $PATTERN"
+    echo "   ${DEPRECATED_PROPS[$PATTERN]}"
+    echo "$RESULTS" | head -3 | sed 's/^/   /'
+    COUNT=$(echo "$RESULTS" | wc -l)
+    [[ $COUNT -gt 3 ]] && echo "   ... and $((COUNT - 3)) more occurrences"
+    echo
+    ((FOUND++))
+  fi
+done
+
+# Check for slot usage (v4 React pattern)
+echo "🔍 Checking for slot usage (v4 pattern)..."
+SLOTS=$(grep -rn "slot=" src/ 2>/dev/null | grep -v "node_modules" | grep -v ".test." | grep -v ".spec." || true)
+if [[ -n "$SLOTS" ]]; then
+  echo "❌ Found slot usage (v4 uses slots, v6 uses props):"
+  echo "$SLOTS" | head -3 | sed 's/^/   /'
+  COUNT=$(echo "$SLOTS" | wc -l)
+  [[ $COUNT -gt 3 ]] && echo "   ... and $((COUNT - 3)) more occurrences"
+  echo "   Convert: <div slot=\"footer\"> → footer={<div>} prop"
+  echo
+  ((FOUND++))
+fi
+
+# Summary
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+if [[ $FOUND -eq 0 ]]; then
+  echo "✅ No deprecated props found!"
+else
+  echo "⚠️  Found $FOUND deprecated prop pattern(s)"
+  echo
+  echo "📖 See references/prop-renames.md for complete mapping"
+  echo "🔧 Fix these before testing to avoid runtime issues"
+fi

--- a/.agents/skills/version-migration/scripts/find-formik.sh
+++ b/.agents/skills/version-migration/scripts/find-formik.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Identifies Formik forms that need migration to React Hook Form
+
+set -euo pipefail
+
+echo "🔍 Scanning for Formik usage..."
+echo
+
+# Find Formik imports
+FORMIK_FILES=$(grep -rl "from 'formik'\|from \"formik\"" src/ 2>/dev/null || true)
+
+if [[ -z "$FORMIK_FILES" ]]; then
+  echo "✅ No Formik usage found"
+  exit 0
+fi
+
+FILE_COUNT=$(echo "$FORMIK_FILES" | wc -l)
+echo "📊 Found Formik in $FILE_COUNT file(s)"
+echo
+
+# Analyze each file
+while IFS= read -r file; do
+  echo "📄 $file"
+  
+  # Check for Formik component
+  grep -q "<Formik" "$file" && echo "  • Uses <Formik> component"
+  
+  # Check for Field component
+  FIELD_COUNT=$(grep -c "<Field" "$file" 2>/dev/null || echo "0")
+  [[ $FIELD_COUNT -gt 0 ]] && echo "  • $FIELD_COUNT <Field> component(s)"
+  
+  # Check for Yup schema
+  grep -q "Yup\." "$file" && echo "  • Uses Yup validation schema"
+  
+  # Check for useFormik hook
+  grep -q "useFormik" "$file" && echo "  • Uses useFormik hook"
+  
+  # Check for Form component
+  grep -q "<Form" "$file" && echo "  • Uses <Form> component"
+  
+  echo
+done <<< "$FORMIK_FILES"
+
+# Check for Yup schemas
+echo "🔍 Checking for Yup validation schemas..."
+YUP_FILES=$(grep -rl "from 'yup'\|from \"yup\"\|import \* as Yup" src/ 2>/dev/null || true)
+
+if [[ -n "$YUP_FILES" ]]; then
+  YUP_COUNT=$(echo "$YUP_FILES" | wc -l)
+  echo "📊 Found Yup in $YUP_COUNT file(s)"
+  echo "$YUP_FILES" | sed 's/^/  • /'
+else
+  echo "✅ No Yup schemas found"
+fi
+
+# Summary
+echo
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "📈 Migration scope:"
+echo "  • Formik files: $FILE_COUNT"
+[[ -n "$YUP_FILES" ]] && echo "  • Yup schema files: $YUP_COUNT"
+
+echo
+echo "📖 Migration guide: references/form-migration.md"
+echo
+echo "🔧 Key changes:"
+echo "  • Formik → IressForm + IressFormField"
+echo "  • <Field as={Input}> → render={(props) => <IressInput {...props} />}"
+echo "  • Yup schema → rules prop per field"
+echo "  • validationSchema → rules={{ required: 'msg', ... }}"
+echo
+echo "⚠️  Form migration is the highest-effort part of v6 upgrade"

--- a/.agents/skills/version-migration/scripts/find-test-utils.sh
+++ b/.agents/skills/version-migration/scripts/find-test-utils.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Finds old IDS v4 test utilities that need migration
+
+set -euo pipefail
+
+echo "🔍 Scanning for old test utilities..."
+echo
+
+FOUND=0
+
+# Check for idsFireEvent
+echo "1️⃣  Checking for idsFireEvent..."
+IDS_FIRE_EVENT=$(grep -rn "idsFireEvent" src/ 2>/dev/null || true)
+if [[ -n "$IDS_FIRE_EVENT" ]]; then
+  echo "  ❌ Found idsFireEvent usage:"
+  echo "$IDS_FIRE_EVENT" | head -5 | sed 's/^/     /'
+  COUNT=$(echo "$IDS_FIRE_EVENT" | wc -l)
+  [[ $COUNT -gt 5 ]] && echo "     ... and $((COUNT - 5)) more occurrences"
+  echo "  ✅ Replace with: fireEvent or userEvent from @testing-library/react"
+  echo
+  ((FOUND++))
+else
+  echo "  ✅ No idsFireEvent usage found"
+fi
+
+# Check for mockLazyLoadedComponents
+echo
+echo "2️⃣  Checking for mockLazyLoadedComponents..."
+MOCK_LAZY=$(grep -rn "mockLazyLoadedComponents" src/ 2>/dev/null || true)
+if [[ -n "$MOCK_LAZY" ]]; then
+  echo "  ❌ Found mockLazyLoadedComponents usage:"
+  echo "$MOCK_LAZY" | sed 's/^/     /'
+  echo "  ✅ Remove: v6 components load synchronously"
+  echo
+  ((FOUND++))
+else
+  echo "  ✅ No mockLazyLoadedComponents usage found"
+fi
+
+# Check for old test utils import
+echo
+echo "3️⃣  Checking for old test utils imports..."
+TEST_UTILS_IMPORT=$(grep -rn "@iress/ids-react-test-utils\|@iress/components-react/test" src/ 2>/dev/null || true)
+if [[ -n "$TEST_UTILS_IMPORT" ]]; then
+  echo "  ❌ Found old test utils imports:"
+  echo "$TEST_UTILS_IMPORT" | sed 's/^/     /'
+  echo "  ✅ Replace with: @testing-library/react"
+  echo
+  ((FOUND++))
+else
+  echo "  ✅ No old test utils imports found"
+fi
+
+# Check for componentLoad
+echo
+echo "4️⃣  Checking for componentLoad..."
+COMPONENT_LOAD=$(grep -rn "componentLoad" src/ 2>/dev/null || true)
+if [[ -n "$COMPONENT_LOAD" ]]; then
+  echo "  ❌ Found componentLoad usage:"
+  echo "$COMPONENT_LOAD" | sed 's/^/     /'
+  echo "  ✅ Remove: Not needed in v6"
+  echo
+  ((FOUND++))
+else
+  echo "  ✅ No componentLoad usage found"
+fi
+
+# Check for old helper functions
+echo
+echo "5️⃣  Checking for old helper functions..."
+HELPERS=$(grep -rn "mapRadioGroupOptions\|mapCheckboxGroupOptions\|mapTabs\|mapMenuItems\|showModal\|showSlideout" src/ 2>/dev/null | grep -v "node_modules" || true)
+if [[ -n "$HELPERS" ]]; then
+  echo "  ❌ Found old helper functions:"
+  echo "$HELPERS" | head -3 | sed 's/^/     /'
+  COUNT=$(echo "$HELPERS" | wc -l)
+  [[ $COUNT -gt 3 ]] && echo "     ... and $((COUNT - 3)) more occurrences"
+  echo "  ✅ Replace with: Direct children or hooks (useModal, useSlideout)"
+  echo
+  ((FOUND++))
+else
+  echo "  ✅ No old helper functions found"
+fi
+
+# Summary
+echo
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+if [[ $FOUND -eq 0 ]]; then
+  echo "✅ No old test utilities found!"
+else
+  echo "⚠️  Found $FOUND test pattern(s) needing migration"
+  echo
+  echo "📖 Migration guide: references/testing-migration.md"
+  echo
+  echo "🔧 Key changes:"
+  echo "  • idsFireEvent → fireEvent / userEvent"
+  echo "  • Remove mockLazyLoadedComponents"
+  echo "  • Use standard @testing-library/react"
+  echo "  • Prefer getByRole over getByTestId"
+fi

--- a/.agents/skills/version-migration/scripts/setup-playwright-vrt.sh
+++ b/.agents/skills/version-migration/scripts/setup-playwright-vrt.sh
@@ -1,0 +1,289 @@
+#!/usr/bin/env bash
+# Generates Playwright VRT test suite based on component usage
+
+set -euo pipefail
+
+echo "🎭 Setting up Playwright Visual Regression Testing..."
+echo
+
+# Check if Playwright is installed
+if ! command -v npx &> /dev/null; then
+  echo "❌ npx not found. Install Node.js first."
+  exit 1
+fi
+
+# Check if already initialized
+if [[ -f "playwright.config.ts" ]]; then
+  echo "⚠️  playwright.config.ts already exists"
+  read -p "Overwrite? (y/N): " -n 1 -r
+  echo
+  [[ ! $REPLY =~ ^[Yy]$ ]] && echo "Skipping config generation" && CONFIG_EXISTS=true
+fi
+
+# Generate config if needed
+if [[ -z "${CONFIG_EXISTS:-}" ]]; then
+  echo "📝 Generating playwright.config.ts..."
+  cat > playwright.config.ts << 'EOF'
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+
+  // Update snapshots with UPDATE_SNAPSHOTS=true
+  updateSnapshots: process.env.UPDATE_SNAPSHOTS === 'true' ? 'all' : 'none',
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  webServer: {
+    command: 'npm start',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+  },
+});
+EOF
+  echo "  ✅ Created playwright.config.ts"
+fi
+
+# Create e2e directory
+mkdir -p e2e
+
+# Detect routing framework
+echo
+echo "🔍 Detecting routing framework..."
+ROUTER_TYPE=""
+ROUTE_LIST=""
+
+if grep -q "react-router" package.json 2>/dev/null; then
+  ROUTER_TYPE="react-router"
+  echo "  ✅ Detected React Router"
+  
+  # Find React Router routes
+  ROUTE_FILES=$(grep -rl "path=" src/ 2>/dev/null | grep -E "\.(tsx?|jsx?)$" || echo "")
+  if [[ -n "$ROUTE_FILES" ]]; then
+    ROUTE_LIST=$(echo "$ROUTE_FILES" | while read -r file; do
+      grep -oE 'path="[^"]*"' "$file" | sed 's/path="//;s/"$//'
+    done | grep -v ":" | grep -v "^\*$" | sort -u)
+  fi
+  
+elif grep -q "next" package.json 2>/dev/null; then
+  ROUTER_TYPE="nextjs"
+  echo "  ✅ Detected Next.js"
+  
+  # Find Next.js pages (app router)
+  if [[ -d "app" ]]; then
+    echo "  📁 Using App Router"
+    ROUTE_LIST=$(find app -name "page.*" -type f 2>/dev/null | while read -r file; do
+      route=$(echo "$file" | sed 's|^app||;s|/page\..*$||')
+      [[ -z "$route" ]] && route="/"
+      [[ "$route" =~ \[ ]] && continue
+      echo "$route"
+    done | sort -u)
+  fi
+  
+  # Find Next.js pages (pages router)
+  if [[ -d "pages" ]]; then
+    echo "  📁 Using Pages Router"
+    PAGES_ROUTES=$(find pages -type f \( -name "*.tsx" -o -name "*.jsx" -o -name "*.ts" -o -name "*.js" \) 2>/dev/null | while read -r file; do
+      route=$(echo "$file" | sed 's|^pages||;s|/index\..*$||;s|\..*$||')
+      [[ -z "$route" ]] && route="/"
+      [[ "$route" =~ \[ ]] && continue
+      [[ "$route" =~ ^/api ]] && continue
+      echo "$route"
+    done | sort -u)
+    ROUTE_LIST="${ROUTE_LIST}${ROUTE_LIST:+$'\n'}${PAGES_ROUTES}"
+  fi
+fi
+
+# Convert to array
+if [[ -n "$ROUTE_LIST" ]]; then
+  mapfile -t ROUTES <<< "$ROUTE_LIST"
+  ROUTES=($(printf '%s\n' "${ROUTES[@]}" | sort -u))
+  echo "  📊 Found ${#ROUTES[@]} route(s)"
+else
+  echo "  ℹ️  No routes detected, using example routes"
+  ROUTES=("/" "/about" "/contact")
+fi
+
+# Generate test file
+echo
+echo "📝 Generating e2e/components.spec.ts..."
+
+# Generate route tests dynamically
+ROUTE_TESTS=""
+for route in "${ROUTES[@]}"; do
+  # Sanitize route for test name
+  TEST_NAME=$(echo "$route" | sed 's|/|-|g;s|^-||;s|-$||')
+  [[ -z "$TEST_NAME" ]] && TEST_NAME="home"
+  
+  ROUTE_TESTS+="
+  test('route: $route', async ({ page }) => {
+    await page.goto('$route');
+    await page.waitForLoadState('networkidle');
+    await expect(page).toHaveScreenshot('route-$TEST_NAME.png', {
+      fullPage: true,
+      animations: 'disabled',
+    });
+  });
+"
+done
+
+cat > e2e/components.spec.ts << EOF
+import { test, expect } from '@playwright/test';
+
+/**
+ * Visual Regression Tests for IDS v6 Migration
+ * 
+ * Auto-generated based on detected routes ($ROUTER_TYPE)
+ * 
+ * BEFORE MIGRATION:
+ *   Run: UPDATE_SNAPSHOTS=true npx playwright test
+ *   This captures baseline screenshots
+ * 
+ * AFTER MIGRATION:
+ *   Run: npx playwright test
+ *   This compares new screenshots to baselines
+ *   Review diffs: npx playwright show-report
+ */
+
+test.describe('Page Routes Visual Regression', () => {$ROUTE_TESTS
+});
+
+test.describe('Interactive Components', () => {
+  // Add tests for interactive states
+  test('button states', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    
+    // Find first button
+    const button = page.getByRole('button').first();
+    if (await button.count() > 0) {
+      // Hover state
+      await button.hover();
+      await expect(page).toHaveScreenshot('button-hover.png', {
+        animations: 'disabled',
+      });
+      
+      // Focus state
+      await button.focus();
+      await expect(page).toHaveScreenshot('button-focus.png', {
+        animations: 'disabled',
+      });
+    }
+  });
+
+  test('form validation', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    
+    // Find and submit first form
+    const form = page.locator('form').first();
+    if (await form.count() > 0) {
+      const submitButton = form.getByRole('button', { name: /submit/i });
+      if (await submitButton.count() > 0) {
+        await submitButton.click();
+        await page.waitForTimeout(500); // Wait for validation
+        await expect(page).toHaveScreenshot('form-validation.png', {
+          fullPage: true,
+          animations: 'disabled',
+        });
+      }
+    }
+  });
+
+  test('modal interaction', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    
+    // Find button that opens modal
+    const modalTrigger = page.getByRole('button', { name: /open|show|modal/i }).first();
+    if (await modalTrigger.count() > 0) {
+      await modalTrigger.click();
+      await page.waitForSelector('[role="dialog"]', { state: 'visible' });
+      await page.waitForTimeout(300); // Wait for animation
+      await expect(page).toHaveScreenshot('modal-open.png', {
+        animations: 'disabled',
+      });
+    }
+  });
+});
+
+test.describe('Responsive Layout', () => {
+  const viewports = [
+    { name: 'mobile', width: 375, height: 667 },
+    { name: 'tablet', width: 768, height: 1024 },
+    { name: 'desktop', width: 1280, height: 720 },
+  ];
+
+  for (const viewport of viewports) {
+    test(\`\${viewport.name} viewport\`, async ({ page }) => {
+      await page.setViewportSize({ width: viewport.width, height: viewport.height });
+      await page.goto('/');
+      await page.waitForLoadState('networkidle');
+      await expect(page).toHaveScreenshot(\`layout-\${viewport.name}.png\`, {
+        fullPage: true,
+        animations: 'disabled',
+      });
+    });
+  }
+});
+EOF
+
+echo "  ✅ Created e2e/components.spec.ts"
+[[ -n "$ROUTER_TYPE" ]] && echo "  📍 Generated tests for ${#ROUTES[@]} route(s)"
+
+# Update package.json scripts
+echo
+echo "📝 Adding npm scripts..."
+if [[ -f "package.json" ]]; then
+  if ! grep -q '"test:vrt"' package.json; then
+    # Add scripts (simplified - manual edit recommended)
+    echo "  ℹ️  Add these scripts to package.json:"
+    echo '    "test:vrt": "playwright test",'
+    echo '    "test:vrt:update": "UPDATE_SNAPSHOTS=true playwright test",'
+    echo '    "test:vrt:ui": "playwright test --ui"'
+  else
+    echo "  ✅ VRT scripts already exist"
+  fi
+fi
+
+# Summary
+echo
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "✅ Playwright VRT setup complete!"
+echo
+echo "📋 Next steps:"
+echo
+echo "1. Install Playwright:"
+echo "   npm install -D @playwright/test"
+echo "   npx playwright install"
+echo
+echo "2. Customize test routes in e2e/components.spec.ts"
+echo
+echo "3. BEFORE migration - capture baselines:"
+echo "   UPDATE_SNAPSHOTS=true npx playwright test"
+echo
+echo "4. Perform IDS v6 migration"
+echo
+echo "5. AFTER migration - run VRT:"
+echo "   npx playwright test"
+echo
+echo "6. Review visual diffs:"
+echo "   npx playwright show-report"
+echo
+echo "📖 Full guide: references/visual-regression-testing.md"

--- a/.agents/skills/version-migration/scripts/validate-migration.sh
+++ b/.agents/skills/version-migration/scripts/validate-migration.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Post-migration validation checks
+
+set -euo pipefail
+
+ERRORS=0
+WARNINGS=0
+
+echo "🔍 Running post-migration validation..."
+echo
+
+# 1. Check for old imports
+echo "1️⃣  Checking for old imports..."
+OLD_IMPORTS=$(grep -r "@iress/oui\|@iress/components-react" src/ 2>/dev/null || true)
+if [[ -n "$OLD_IMPORTS" ]]; then
+  echo "  ❌ Found old imports:"
+  echo "$OLD_IMPORTS" | head -5
+  [[ $(echo "$OLD_IMPORTS" | wc -l) -gt 5 ]] && echo "  ... and $(($(echo "$OLD_IMPORTS" | wc -l) - 5)) more"
+  ((ERRORS++))
+else
+  echo "  ✅ No old imports found"
+fi
+
+# 2. Check for old test utils
+echo
+echo "2️⃣  Checking for old test utilities..."
+OLD_TEST_UTILS=$(grep -r "idsFireEvent\|mockLazyLoadedComponents\|@iress/ids-react-test-utils" src/ 2>/dev/null || true)
+if [[ -n "$OLD_TEST_UTILS" ]]; then
+  echo "  ❌ Found old test utils:"
+  echo "$OLD_TEST_UTILS" | head -5
+  [[ $(echo "$OLD_TEST_UTILS" | wc -l) -gt 5 ]] && echo "  ... and $(($(echo "$OLD_TEST_UTILS" | wc -l) - 5)) more"
+  ((ERRORS++))
+else
+  echo "  ✅ No old test utils found"
+fi
+
+# 3. Check for deprecated props
+echo
+echo "3️⃣  Checking for deprecated props..."
+DEPRECATED_PROPS=$(grep -rE "variant=|isOpen=|gutter=|mode=\"link\"|mode='link'|optional=|legend=" src/ 2>/dev/null | grep -v "node_modules" || true)
+if [[ -n "$DEPRECATED_PROPS" ]]; then
+  echo "  ⚠️  Found potentially deprecated props:"
+  echo "$DEPRECATED_PROPS" | head -5
+  [[ $(echo "$DEPRECATED_PROPS" | wc -l) -gt 5 ]] && echo "  ... and $(($(echo "$DEPRECATED_PROPS" | wc -l) - 5)) more"
+  echo "  ℹ️  Review these manually - some may be false positives"
+  ((WARNINGS++))
+else
+  echo "  ✅ No obvious deprecated props found"
+fi
+
+# 4. Check for required CSS import
+echo
+echo "4️⃣  Checking for IDS v6 CSS import..."
+CSS_IMPORT=$(grep -r "@iress-oss/ids-components/dist/style.css\|@iress-oss/ids-components/styled-system/styles.css" src/ 2>/dev/null || true)
+if [[ -z "$CSS_IMPORT" ]]; then
+  echo "  ❌ Missing CSS import"
+  echo "  Add to app entry: import '@iress-oss/ids-components/dist/style.css';"
+  ((ERRORS++))
+else
+  echo "  ✅ CSS import found"
+fi
+
+# 5. Check for Formik remnants
+echo
+echo "5️⃣  Checking for Formik usage..."
+FORMIK=$(grep -r "from 'formik'\|from \"formik\"" src/ 2>/dev/null || true)
+if [[ -n "$FORMIK" ]]; then
+  echo "  ⚠️  Formik still in use:"
+  echo "$FORMIK" | head -3
+  [[ $(echo "$FORMIK" | wc -l) -gt 3 ]] && echo "  ... and $(($(echo "$FORMIK" | wc -l) - 3)) more"
+  echo "  ℹ️  Consider migrating to IressForm + IressFormField"
+  ((WARNINGS++))
+else
+  echo "  ✅ No Formik usage found"
+fi
+
+# 6. Check package.json
+echo
+echo "6️⃣  Checking package.json..."
+if grep -q "@iress-oss/ids-components" package.json; then
+  VERSION=$(grep "@iress-oss/ids-components" package.json | grep -o '[0-9][^"]*')
+  echo "  ✅ IDS v6 in package.json: $VERSION"
+else
+  echo "  ❌ @iress-oss/ids-components not in package.json"
+  ((ERRORS++))
+fi
+
+# Summary
+echo
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+if [[ $ERRORS -eq 0 && $WARNINGS -eq 0 ]]; then
+  echo "✅ All validation checks passed!"
+elif [[ $ERRORS -eq 0 ]]; then
+  echo "⚠️  Validation complete with $WARNINGS warning(s)"
+  echo "Review warnings above - they may need attention"
+else
+  echo "❌ Validation failed with $ERRORS error(s) and $WARNINGS warning(s)"
+  echo "Fix errors above before proceeding"
+  exit 1
+fi
+
+echo
+echo "📋 Manual checks still needed:"
+echo "  • Visual inspection of all pages"
+echo "  • Form submission and validation"
+echo "  • Test suite passes"
+echo "  • Accessibility (keyboard nav, screen readers)"
+echo "  • Production build succeeds"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^5.0.1",
-    "@iress-oss/ids-components": "^6.0.0-alpha.33",
+    "@iress-oss/ids-components": "^6.0.0-alpha.34",
     "@iress-oss/ids-storybook-config": "^0.5.0",
     "@iress-oss/ids-storybook-okta": "^0.1.2",
     "@iress-oss/ids-storybook-sandbox": "^0.2.2",

--- a/packages/components/docs/Resources/030-MigrationGuides/v6.mdx
+++ b/packages/components/docs/Resources/030-MigrationGuides/v6.mdx
@@ -82,6 +82,14 @@ SASS modules have been replaced with [Panda CSS](https://panda-css.com/) for typ
 | New `onDismiss`        | Add dismiss functionality                                                       |
 | New `multiLine`        | Display on multiple lines for longer content (single row after `md` by default) |
 
+### Autocomplete
+
+| Change                  | Details                                                |
+| ----------------------- | ------------------------------------------------------ |
+| Removed `watermark`     | No longer supported                                    |
+| Hook: `options` required | `options` is now required in `useAutocompleteSearch`  |
+| Hook: `displayResults`  | Removed from hook return                               |
+
 ### Badge → Pill (renamed)
 
 `IressBadge` has been renamed to `IressPill`. Use the new component.
@@ -125,6 +133,7 @@ SASS modules have been replaced with [Panda CSS](https://panda-css.com/) for typ
 | Removed `hiddenControl` and `touch` | Use the new `variant` prop (`"card"` or `"touch"`)                             |
 | New `variant` prop                  | `"card"` — checkbox on top right with heading. `"touch"` — larger touch target |
 | Updated `ref`                       | Now exposes `blur()`, `focus()`, and `input` (underlying DOM element)          |
+| Removed ref methods                 | `check()` and `reset()` removed from ref                                       |
 
 ### CheckboxGroup
 
@@ -141,6 +150,12 @@ No longer has a `ref` prop. Wrap the element in a `<div ref={elementRef} />` and
 ### Col
 
 No changes.
+
+### Combobox (removed)
+
+`IressCombobox` and `IressMultiCombobox` have been removed. Use:
+- `IressSelect` for restricted selection from options
+- `IressAutocomplete` for free-text input with suggestions
 
 ### Container
 
@@ -177,6 +192,9 @@ No changes.
 | New `supplementary` / `renderSupplementary` | Shown below the field; hidden when `error` or `errorMessages` is set                            |
 | Errors now below field                      | Errors animate in below the field                                                               |
 | Built-in bottom margin                      | Fields have bottom margin for error/supplementary area — **do not wrap fields in `IressStack`** |
+| New `horizontal`                            | Inline label/input layout                                                                       |
+| New `labelWidth`                            | Control label container width                                                                   |
+| New `removeErrorMargin`                     | Removes error space reservation                                                                 |
 
 ### FieldGroup
 
@@ -197,11 +215,14 @@ Use the `srOnly` or `hide` styling props available on any component.
 
 ### Icon
 
-| Change                  | Details                                                                                             |
-| ----------------------- | --------------------------------------------------------------------------------------------------- |
-| Removed `mode`          | Use `color` instead                                                                                 |
-| `name` is now type-safe | IDE autocompletion available                                                                        |
-| Removed `size`          | Inherits font size from parent. Use custom CSS for specific sizes; use `IressImage` for large icons |
+| Change                    | Details                                                                                             |
+| ------------------------- | --------------------------------------------------------------------------------------------------- |
+| Removed `mode`            | Use `color` instead                                                                                 |
+| `name` is now type-safe   | IDE autocompletion available                                                                        |
+| Removed `size`            | Inherits font size from parent. Use custom CSS for specific sizes; use `IressImage` for large icons |
+| New `IressIconProvider`   | Required for optimal Material Symbols usage with font subsetting                                    |
+| New `type` prop           | Select icon provider (`'fontawesome'` \| `'material'`)                                              |
+| New `filled` prop         | Material Symbols filled variant                                                                     |
 
 ### Image
 
@@ -209,7 +230,10 @@ New component for displaying responsive images.
 
 ### Inline
 
-`gutter` changed to `gap`, now accepts the larger spacing token spectrum.
+| Change          | Details                                                    |
+| --------------- | ---------------------------------------------------------- |
+| `gutter` → `gap`| Accepts the larger spacing token spectrum                  |
+| New `rowGap`    | Set top/bottom gap when content wraps                      |
 
 ### Input
 
@@ -240,7 +264,7 @@ New component for anchor links in text paragraphs. Accepts the same props as `Ir
 | `defaultValue`/`onChange`/`value` | Type-aware based on `multiSelect` — arrays when `true`, single value when `false` |
 | Removed `MenuSelected` interface  | Menu is now generic extending `FormControlValue`                                  |
 | Removed `mapMenuItems`            | Map `IressMenuItem` using arrays directly                                         |
-| Removed `role="nav"`              | Nav styling removed; use custom CSS                                               |
+| Removed `role="nav"`              | Nav styling removed. For navigation menus, use `IressSideNav` pattern or custom styling          |
 | New `radio` variant               | Radio prepend to show selection                                                   |
 | New `subdraw` variant             | Menu groups as popovers                                                           |
 | New `side` variant                | Side menu with collapsible groups                                                 |
@@ -272,7 +296,7 @@ No changes.
 
 | Change                       | Details                                                                                                                              |
 | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `padding` → `p` styling prop | —                                                                                                                                    |
+| `padding` → `p` styling prop | Default padding changed from `'md'` to `'lg'`                                                                                        |
 | Removed `fullpage`           | Modal no longer covers the entire screen on small devices                                                                            |
 | Custom heading node          | `id` is no longer automatically added. Set the `id` prop on your custom node to connect to the modal. String headings work as before |
 | No shadow                    | Slight blur on the background instead                                                                                                |
@@ -326,6 +350,9 @@ New component supporting the data colour spectrum with automatic rounded corners
 | Removed `width`               | Use `contentStyle` prop with custom CSS                                                                    |
 | Deprecated `contentClassName` | Use `contentStyle.className`                                                                               |
 | New `contentStyle`            | Customise `className`, `style`, and styling props on the popover content                                   |
+| New `fluid`                   | Full container width                                                                                       |
+| New `offset`                  | Number or object for popover positioning offset (default: 5)                                               |
+| New `nested`                  | Nested navigation behaviour                                                                                |
 | Z-index                       | Now uses z-index for consistent layering                                                                   |
 
 ### Progress
@@ -335,6 +362,16 @@ New component supporting the data colour spectrum with automatic rounded corners
 | Renders `<meter>` or `<progress>` | `<meter>` when `min` is set; `<progress>` otherwise                                  |
 | Single element                    | No more `__progressbar` test id                                                      |
 | Simplified ARIA                   | Only `aria-label` is rendered. If testing by attribute (not role), update your tests |
+
+### Provider
+
+| Change                  | Details                                                                      |
+| ----------------------- | ---------------------------------------------------------------------------- |
+| Removed `noIcons`       | Use `noDefaultFont` instead                                                  |
+| Removed `injectPushStyles` | No longer available                                                       |
+| New `noSubsetting`      | Controls automatic font subsetting via Google Fonts CDN for icons            |
+| New `noDefaultFont`     | Controls loading of default Iress font from CDN                              |
+| Icon handling           | Now uses `IressIconProvider` with Material Symbols instead of icon CSS       |
 
 ### Radio
 
@@ -349,6 +386,10 @@ New component supporting the data colour spectrum with automatic rounded corners
 | ----------------------------------- | -------------------------------------------------- |
 | `readonly` → `readOnly`             | —                                                  |
 | Removed `hiddenControl` and `touch` | Use the new `variant` prop (`"card"` or `"touch"`) |
+
+### RadioMark
+
+New component for rendering a standalone radio mark indicator (similar to `IressCheckboxMark`).
 
 ### Readonly
 
@@ -375,6 +416,22 @@ Styled to match other input text sizes. Use the new `textStyle` prop for larger 
 | New `native` prop                 | Renders a browser-native select (replaces the old `IressSelect`). Note: still passes `LabelValueMeta` as the value |
 | Grouped items                     | Now supported                                                                                                      |
 | New hover and focus states        | —                                                                                                                  |
+
+The v5 native `IressSelect` with `children` (option elements) is replaced by `IressSelect` with the `native` prop:
+
+**Before (v5):**
+
+```tsx
+<IressSelect>
+  <IressSelectOption value="1">Option 1</IressSelectOption>
+</IressSelect>
+```
+
+**After (v6):**
+
+```tsx
+<IressSelect native options={[{ label: 'Option 1', value: '1' }]} />
+```
 
 ### SelectOption (removed)
 
@@ -419,7 +476,13 @@ Removed `name` prop. All spinners are now consistent across Iress products.
 | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `gutter` → `gap`        | Accepts the larger spacing token spectrum                                                                                                        |
 | No longer uses `margin` | Uses flexbox. Use `horizontalAlign` or wrap children with `IressInline` for inline display. Use `alignSelf` on children for individual alignment |
-| Lists inside Stack      | Use the new `element` prop to render as a list, then place list items inside                                                                     |
+| New `element` prop      | Render as a different HTML element (e.g. `<ul>` for lists)                                                                                       |
+| New `horizontalAlign`   | Set horizontal alignment of stack content                                                                                                        |
+| New `verticalAlign`     | Set vertical alignment with additional options (`'between'`, `'around'`, `'evenly'`)                                                             |
+
+### Styled
+
+New component for applying IDS styling props to any element or component without using the styled-system JSX components directly.
 
 ### Table
 
@@ -437,10 +500,13 @@ Removed `name` prop. All spinners are now consistent across Iress products.
 
 ### TabSet
 
-| Change            | Details                                      |
-| ----------------- | -------------------------------------------- |
-| Removed `mapTabs` | Use `Array.map` to map objects to `IressTab` |
-| Selected tabs     | Now have a highlighted background            |
+| Change               | Details                                      |
+| -------------------- | -------------------------------------------- |
+| Removed `mapTabs`    | Use `Array.map` to map objects to `IressTab` |
+| Selected tabs        | Now have a highlighted background            |
+| New `panelStyle`     | Custom style for panel area                  |
+| New `tabHolderStyle` | Custom style for tab holder area             |
+| New `type`           | Tab styling type (`'primary'` \| `'secondary'`) |
 
 ### Tag
 
@@ -452,10 +518,14 @@ Removed `name` prop. All spinners are now consistent across Iress products.
 
 ### TagInput
 
-| Change                         | Details                     |
-| ------------------------------ | --------------------------- |
-| Removed `testid__input__input` | Use `testid__input` instead |
-| Removed `testid__items`        | —                           |
+| Change                         | Details                                              |
+| ------------------------------ | ---------------------------------------------------- |
+| Removed `testid__input__input` | Use `testid__input` instead                          |
+| Removed `testid__items`        | —                                                    |
+| `onTagDelete` signature        | Now includes event: `(label, e) => void`             |
+| `onTagDeleteAll` signature     | Now includes event: `(label, e) => void`             |
+| New `tagLimit`                 | Limit tags before shortening (default: 5)            |
+| New `selectedOptionsTagText`   | Text for tag count display                           |
 
 ### Text
 
@@ -483,6 +553,7 @@ Removed `name` prop. All spinners are now consistent across Iress products.
 | `headingText` → `heading`   | —                                                         |
 | No `position` at hook level | Set `position` on `IressToasterProvider`                  |
 | Simple string toasts        | Pass a string directly for a simple message               |
+| `status` value change       | `'error'` is now `'danger'` (Alert-based)                 |
 
 ### Toggle
 
@@ -490,6 +561,15 @@ Removed `name` prop. All spinners are now consistent across Iress products.
 | ----------------------- | ------------------------------------------------------------------------------------ |
 | Controlled/uncontrolled | Now uses `checked`/`defaultChecked` like checkbox. Explicitly set whether controlled |
 | Removed forwarded `ref` | Wrap in a `<div>` and use query selectors if needed                                  |
+| New `defaultChecked`    | For uncontrolled mode                                                                |
+| New `disabled`          | Disable the toggle                                                                   |
+
+### Tooltip
+
+| Change                       | Details                                                    |
+| ---------------------------- | ---------------------------------------------------------- |
+| `align` prop simplified      | Removed deprecated enum option, now uses string literals   |
+| Removed `IressTooltip.Align` | Use string values directly                                 |
 
 ### ValidationLink
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iress-oss/ids-components",
-  "version": "6.0.0-alpha.33",
+  "version": "6.0.0-alpha.34",
   "description": "Iress React Component Library",
   "license": "Apache-2.0",
   "type": "module",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1360,7 +1360,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@iress-oss/ids-components@npm:^6.0.0-alpha.33, @iress-oss/ids-components@workspace:packages/components":
+"@iress-oss/ids-components@npm:^6.0.0-alpha.34, @iress-oss/ids-components@workspace:packages/components":
   version: 0.0.0-use.local
   resolution: "@iress-oss/ids-components@workspace:packages/components"
   dependencies:
@@ -1726,7 +1726,7 @@ __metadata:
   resolution: "@iress/design-system-monorepo@workspace:."
   dependencies:
     "@chromatic-com/storybook": "npm:^5.0.1"
-    "@iress-oss/ids-components": "npm:^6.0.0-alpha.33"
+    "@iress-oss/ids-components": "npm:^6.0.0-alpha.34"
     "@iress-oss/ids-storybook-config": "npm:^0.5.0"
     "@iress-oss/ids-storybook-okta": "npm:^0.1.2"
     "@iress-oss/ids-storybook-sandbox": "npm:^0.2.2"


### PR DESCRIPTION
This pull request significantly improves the migration guide for moving applications between IDS (Iress Design System) and OUI stacks, with a focus on clarity, actionable steps, and troubleshooting. The most important changes include the addition of pre- and post-migration checklists, expanded decision tables with direct references, a dedicated v5→v6 migration section, improved prop rename documentation, and a comprehensive gotchas guide.

**Migration workflow improvements:**

* Added a detailed "Pre-Migration Assessment" section outlining scripts and manual checks to run before starting migration, improving readiness and reducing errors.
* Added a "Post-Migration Validation" checklist and described automated/manual steps to ensure migration success, including visual regression and accessibility checks.

**Documentation and reference enhancements:**

* Expanded the migration decision table to include direct links to reference guides for each migration path, making it easier to find relevant documentation.
* Added a dedicated section for IDS v5→v6 migration, summarizing key changes and linking to a detailed migration reference.
* Improved prop rename tables to clearly distinguish between OUI and IDS v4/v5 props, making it easier to identify necessary code changes.

**Troubleshooting resources:**

* Created a new comprehensive gotchas guide (`references/common-gotchas.md`) covering critical breaking changes, version-specific issues, component API changes, and form architecture migration patterns.