### PR TITLE
chore(icon): implement CSP nonce support for dynamic font loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^5.0.1",
-    "@iress-oss/ids-components": "^6.0.0-alpha.35",
+    "@iress-oss/ids-components": "^6.0.0-alpha.36",
     "@iress-oss/ids-storybook-config": "^0.5.0",
     "@iress-oss/ids-storybook-okta": "^0.1.2",
     "@iress-oss/ids-storybook-sandbox": "^0.2.2",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iress-oss/ids-components",
-  "version": "6.0.0-alpha.35",
+  "version": "6.0.0-alpha.36",
   "description": "Iress React Component Library",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/components/src/components/Icon/IconProvider.tsx
+++ b/packages/components/src/components/Icon/IconProvider.tsx
@@ -169,7 +169,7 @@ export const IressIconProvider = <P extends IconType = 'material'>({
       {children}
       {type === 'material' && container && (
         <FontLoader
-          url={`https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@${MATERIAL_SYMBOLS.opticalSize},${MATERIAL_SYMBOLS.weight},0..1,${MATERIAL_SYMBOLS.grade}`}
+          url={`https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@${MATERIAL_SYMBOLS.opticalSize},${MATERIAL_SYMBOLS.weight},0..1,${MATERIAL_SYMBOLS.grade}&icon_names=home`}
           container={container}
           onlyShadow
           keyPrefix="material-symbols-fonts"

--- a/packages/components/src/components/Icon/components/FontLoader.tsx
+++ b/packages/components/src/components/Icon/components/FontLoader.tsx
@@ -1,6 +1,7 @@
 import { createPortal } from 'react-dom';
 import type { ShadowContainer } from '@/types';
 import type { IressTestProps } from '@/interfaces';
+import { getNonce } from '@helpers/dom/getNonce';
 
 export interface FontLoaderProps extends IressTestProps {
   /**
@@ -58,18 +59,23 @@ export const FontLoader = ({
   }
 
   const styleContent = `@import url("${url}") layer(reset);`;
+  const nonce = getNonce() ?? undefined;
 
   return (
     <>
       {!onlyShadow &&
         createPortal(
-          <style data-url={url}>{styleContent}</style>,
+          <style nonce={nonce} data-url={url}>
+            {styleContent}
+          </style>,
           document.head,
           `${keyPrefix}-head`,
         )}
       {target &&
         createPortal(
-          <style data-url={url}>{styleContent}</style>,
+          <style nonce={nonce} data-url={url}>
+            {styleContent}
+          </style>,
           target,
           `${keyPrefix}-shadow`,
         )}

--- a/packages/components/src/components/Icon/hooks/useDynamicFontSubsetting.test.ts
+++ b/packages/components/src/components/Icon/hooks/useDynamicFontSubsetting.test.ts
@@ -31,16 +31,22 @@ describe('useDynamicFontSubsetting', () => {
       configurable: true,
     });
 
-    // Clear any existing style elements
+    // Clear any existing style elements and nonce meta tags
     document.querySelectorAll('style[data-test-font]').forEach((el) => {
+      el.remove();
+    });
+    document.querySelectorAll("meta[name='csp-nonce']").forEach((el) => {
       el.remove();
     });
   });
 
   afterEach(() => {
     vi.clearAllMocks();
-    // Clean up style elements
+    // Clean up style elements and nonce meta tags
     document.querySelectorAll('style[data-test-font]').forEach((el) => {
+      el.remove();
+    });
+    document.querySelectorAll("meta[name='csp-nonce']").forEach((el) => {
       el.remove();
     });
   });
@@ -225,10 +231,13 @@ describe('useDynamicFontSubsetting', () => {
         }),
       );
 
-      // Wait a bit to ensure no fetch happens
+      // Wait a bit to ensure no style injection happens
       await new Promise((resolve) => setTimeout(resolve, 100));
 
       expect(mockFetch).not.toHaveBeenCalled();
+      expect(
+        document.querySelector('style[data-test-font]'),
+      ).not.toBeInTheDocument();
     });
 
     it('returns empty loadedIcons when disabled', () => {
@@ -290,7 +299,7 @@ describe('useDynamicFontSubsetting', () => {
   });
 
   describe('URL caching', () => {
-    it('does not refetch if URL has not changed', async () => {
+    it('does not recreate style if URL has not changed', async () => {
       const icons = new Set(['icon1']);
 
       const { rerender } = renderHook(
@@ -525,6 +534,51 @@ describe('useDynamicFontSubsetting', () => {
         expect(styleElements[0].getAttribute('data-url')).toBe(
           'https://fonts.test/icon2',
         );
+      });
+    });
+  });
+
+  describe('CSP nonce support', () => {
+    it('adds nonce attribute to style element when csp-nonce meta tag exists', async () => {
+      const meta = document.createElement('meta');
+      meta.setAttribute('name', 'csp-nonce');
+      meta.setAttribute('content', 'test-nonce-123');
+      document.head.appendChild(meta);
+
+      const icons = new Set(['icon1']);
+
+      renderHook(() =>
+        useDynamicFontSubsetting({
+          icons,
+          buildUrl: (icons) => `https://fonts.test/${icons.join(',')}`,
+          dataAttribute: 'test-font',
+          fontFamily: 'Test Font',
+        }),
+      );
+
+      await waitFor(() => {
+        const styleElement = document.querySelector('style[data-test-font]');
+        expect(styleElement).toBeInTheDocument();
+        expect(styleElement?.getAttribute('nonce')).toBe('test-nonce-123');
+      });
+    });
+
+    it('does not add nonce attribute when csp-nonce meta tag is absent', async () => {
+      const icons = new Set(['icon1']);
+
+      renderHook(() =>
+        useDynamicFontSubsetting({
+          icons,
+          buildUrl: (icons) => `https://fonts.test/${icons.join(',')}`,
+          dataAttribute: 'test-font',
+          fontFamily: 'Test Font',
+        }),
+      );
+
+      await waitFor(() => {
+        const styleElement = document.querySelector('style[data-test-font]');
+        expect(styleElement).toBeInTheDocument();
+        expect(styleElement?.getAttribute('nonce')).toBeNull();
       });
     });
   });

--- a/packages/components/src/components/Icon/hooks/useDynamicFontSubsetting.ts
+++ b/packages/components/src/components/Icon/hooks/useDynamicFontSubsetting.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
+import { getNonce } from '@helpers/dom/getNonce';
 
 export interface UseDynamicFontSubsettingOptions {
   /**
@@ -151,7 +152,9 @@ export const useDynamicFontSubsetting = ({
 
         // Create new style element with CSS in reset layer
         // This ensures Panda CSS utilities can override Material Symbols defaults
+        const nonce = getNonce();
         const style = document.createElement('style');
+        if (nonce) style.setAttribute('nonce', nonce);
         style.textContent = layeredCSS;
         style.setAttribute(`data-${dataAttribute}`, 'true');
         style.setAttribute('data-url', url);

--- a/packages/components/src/helpers/dom/getNonce.ts
+++ b/packages/components/src/helpers/dom/getNonce.ts
@@ -1,0 +1,10 @@
+/**
+ * Retrieves the CSP nonce from the `<meta name="csp-nonce">` tag in the document head.
+ * This nonce is required for dynamically injected inline styles when a Content Security Policy
+ * with nonce-based style-src is active (which causes 'unsafe-inline' to be ignored).
+ *
+ * @returns The nonce string, or null if not found
+ */
+export const getNonce = (): string | null =>
+  document.querySelector("meta[name='csp-nonce']")?.getAttribute('content') ??
+  null;

--- a/packages/components/src/patterns/Shadow/Shadow.tsx
+++ b/packages/components/src/patterns/Shadow/Shadow.tsx
@@ -11,6 +11,7 @@ import idsCss from '../../styled-system/styles.css?raw';
 import { defaultFonts } from '@iress-oss/ids-tokens';
 import { type IressUnstyledProps } from '@/types';
 import { IressProvider } from '@/components/Provider';
+import { getNonce } from '@helpers/dom/getNonce';
 
 export interface IressShadowProps extends IressUnstyledProps {
   /**
@@ -65,9 +66,7 @@ export const IressShadow = forwardRef<ShadowRoot | null, IressShadowProps>(
         const shadow = hostRef.current.attachShadow({ mode: 'open' });
 
         const idsStyle = document.createElement('style');
-        const nonce = document
-          .querySelector("meta[name='csp-nonce']")
-          ?.getAttribute('content');
+        const nonce = getNonce();
         if (nonce) idsStyle.setAttribute('nonce', nonce);
 
         idsStyle.textContent = idsCss;
@@ -117,9 +116,7 @@ export const IressShadow = forwardRef<ShadowRoot | null, IressShadowProps>(
           return;
         }
         const style = document.createElement('style');
-        const nonce = document
-          .querySelector("meta[name='csp-nonce']")
-          ?.getAttribute('content');
+        const nonce = getNonce();
         if (nonce) style.setAttribute('nonce', nonce);
         style.setAttribute('id', key);
         style.textContent = contents;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1360,7 +1360,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@iress-oss/ids-components@npm:^6.0.0-alpha.35, @iress-oss/ids-components@workspace:packages/components":
+"@iress-oss/ids-components@npm:^6.0.0-alpha.36, @iress-oss/ids-components@workspace:packages/components":
   version: 0.0.0-use.local
   resolution: "@iress-oss/ids-components@workspace:packages/components"
   dependencies:
@@ -1726,7 +1726,7 @@ __metadata:
   resolution: "@iress/design-system-monorepo@workspace:."
   dependencies:
     "@chromatic-com/storybook": "npm:^5.0.1"
-    "@iress-oss/ids-components": "npm:^6.0.0-alpha.35"
+    "@iress-oss/ids-components": "npm:^6.0.0-alpha.36"
     "@iress-oss/ids-storybook-config": "npm:^0.5.0"
     "@iress-oss/ids-storybook-okta": "npm:^0.1.2"
     "@iress-oss/ids-storybook-sandbox": "npm:^0.2.2"


### PR DESCRIPTION
This pull request introduces support for CSP (Content Security Policy) nonces in dynamically injected style tags, ensuring compatibility with stricter security policies. It does so by centralizing nonce retrieval and applying it consistently throughout the component library. The update also includes comprehensive tests for nonce handling and minor dependency version bumps.

**CSP Nonce Support and Refactoring:**

* Introduced a new helper function `getNonce` in `@helpers/dom/getNonce` to retrieve the CSP nonce from a `<meta name="csp-nonce">` tag, and refactored all dynamic style injections (including in `IressShadow`, `FontLoader`, and `useDynamicFontSubsetting`) to use this helper for consistent nonce application. [[1]](diffhunk://#diff-6d1d67183d13ceacebfd1c4ad4806ac762e7ede97d240af5245efba1e4ef4038R1-R10) [[2]](diffhunk://#diff-72b84f604adf31d7fda121a07799079189f113d5973eb7b64742a596ce2771caR2) [[3]](diffhunk://#diff-72b84f604adf31d7fda121a07799079189f113d5973eb7b64742a596ce2771caR155-R157) [[4]](diffhunk://#diff-0a9ba73004a96edecae5b106b847ab5bbf904cf8d8e7635c995d4f6548acacc9R4) [[5]](diffhunk://#diff-0a9ba73004a96edecae5b106b847ab5bbf904cf8d8e7635c995d4f6548acacc9R62-R78) [[6]](diffhunk://#diff-a19e56e0ca39e2821d3bf75ce83c48578f5b1046ebd0fa63aa18c977e3c1d9caR14) [[7]](diffhunk://#diff-a19e56e0ca39e2821d3bf75ce83c48578f5b1046ebd0fa63aa18c977e3c1d9caL68-R69) [[8]](diffhunk://#diff-a19e56e0ca39e2821d3bf75ce83c48578f5b1046ebd0fa63aa18c977e3c1d9caL120-R119)

**Testing Enhancements:**

* Expanded tests for `useDynamicFontSubsetting` to cover CSP nonce behavior, including scenarios where the nonce meta tag is present or absent, and improved cleanup procedures for style and meta elements in test setup and teardown. [[1]](diffhunk://#diff-399fc99cbe18b70016c4daf6cde1d18d955a07e7776a391295bd2caf0f5a2d69L34-R51) [[2]](diffhunk://#diff-399fc99cbe18b70016c4daf6cde1d18d955a07e7776a391295bd2caf0f5a2d69L228-R240) [[3]](diffhunk://#diff-399fc99cbe18b70016c4daf6cde1d18d955a07e7776a391295bd2caf0f5a2d69L293-R302) [[4]](diffhunk://#diff-399fc99cbe18b70016c4daf6cde1d18d955a07e7776a391295bd2caf0f5a2d69R540-R584)

**Dependency Updates:**

* Bumped `@iress-oss/ids-components` version from `6.0.0-alpha.35` to `6.0.0-alpha.36` in both root and package-level `package.json` files. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L15-R15) [[2]](diffhunk://#diff-2c76dc06185f93bec73660e15338433b95eac6707317564c0f778f5b9abe446cL3-R3)

**Other Minor Improvements:**

* Updated the Material Symbols font URL in `IconProvider.tsx` to include an `icon_names=home` query parameter, potentially for optimization.