### PR TITLE
chore(docs): update migration guides and component documentation for IressReadonly and IressSelect enhancements

### DIFF
--- a/.agents/skills/ui-translation/references/component-mapping.md
+++ b/.agents/skills/ui-translation/references/component-mapping.md
@@ -25,7 +25,7 @@
 | Toggle switch            | `IressToggle`                       | `<IressToggle label="Enable" />`                                                                                               |
 | Slider / range           | `IressSlider`                       | `<IressSlider min={0} max={100} />`                                                                                            |
 | Autocomplete / typeahead | `IressAutocomplete`                 | See component docs                                                                                                             |
-| Read-only display        | `IressReadonly`                     | `<IressReadonly label="Status" value="Active" />`                                                                              |
+| Read-only display        | `IressReadonly`                     | `<IressReadonly label="Status" value="Active" />` — supports `actions` prop for inline action buttons (e.g. edit toggle) |
 
 ## Layout
 

--- a/.agents/skills/version-migration/references/common-gotchas.md
+++ b/.agents/skills/version-migration/references/common-gotchas.md
@@ -71,6 +71,9 @@
 | `IressSlider` `label` prop gone      | API changed                                      | Use `aria-label` or wrap in `IressFormField`                         |
 | `IressTabs` `activeTabIndex` gone    | API changed                                      | Use `selected`/`defaultSelected` with tab `value` props              |
 | `IressSelect` options format changed | Now uses `LabelValueMeta` objects                | Use `{ label: 'Text', value: 'val' }` format                         |
+| `IressSelect` `value` not selecting | Passing a string instead of `LabelValueMeta`     | v6 now accepts plain strings for `value`/`defaultValue` — ensure the string matches an option's `value` field. A console warning is logged if the value can't be resolved against the available options |
+| `IressPopover` content has extra padding | Default padding added in v6                  | Popover content now has `padding: spacing.4` by default. Override with `contentStyle={{ padding: 'spacing.0' }}` if you were providing your own inner padding |
+| `IressReadonly` CSS selectors broken | DOM structure changed                            | Inner content is now wrapped in an additional `wrapper` div inside `root`. Update CSS selectors targeting direct children of the readonly root element |
 | `IressModal` `title` not rendering   | Prop renamed                                     | Use `heading` prop                                                   |
 | `IressSlideout` `eleToPush` selector | Needs valid CSS selector or element ref          | Pass string selector, HTMLElement, or React ref                      |
 

--- a/.agents/skills/version-migration/references/component-renames.md
+++ b/.agents/skills/version-migration/references/component-renames.md
@@ -84,5 +84,5 @@ Components that changed names between versions. All other IDS components keep th
 | `IressButtonCard`            | Card rendered as a button                                                                                                                       |
 | `IressLinkCard`              | Card rendered as a link                                                                                                                         |
 | `IressFormValidationSummary` | Form validation summary alert                                                                                                                   |
-| `IressReadonly`              | Read-only display of form values                                                                                                                |
+| `IressReadonly`              | Read-only display of form values (supports `actions` prop for inline action buttons)                                                            |
 | `IressSpinner`               | Loading spinner                                                                                                                                 |

--- a/.agents/skills/version-migration/references/v5-to-v6-migration.md
+++ b/.agents/skills/version-migration/references/v5-to-v6-migration.md
@@ -123,13 +123,15 @@ This document covers changes specific to migrating from IDS v5 (`@iress-oss/ids-
 
 ### Select (was RichSelect)
 
-| v5 prop       | v6 prop       | Notes                                      |
-| ------------- | ------------- | ------------------------------------------ |
-| Component     | `IressSelect` | `IressRichSelect` renamed to `IressSelect` |
-| `options`     | `options`     | Unchanged                                  |
-| `value`       | `value`       | Unchanged                                  |
-| `multiSelect` | `multiSelect` | Unchanged                                  |
-| —             | `native`      | New: renders native `<select>` element     |
+| v5 prop       | v6 prop            | Notes                                                                                  |
+| ------------- | ------------------ | -------------------------------------------------------------------------------------- |
+| Component     | `IressSelect`      | `IressRichSelect` renamed to `IressSelect`                                             |
+| `options`     | `options`          | Unchanged                                                                              |
+| `value`       | `value`            | Now also accepts a plain string or `FormControlValue` (resolves to matching option)    |
+| `multiSelect` | `multiSelect`      | Unchanged                                                                              |
+| —             | `defaultValue`     | Accepts `LabelValueMeta` or plain string for uncontrolled pre-selection                |
+| —             | `multiSelectLimit` | New: limits visible selected tags before collapsing to "+N more" (default `5`)         |
+| —             | `native`           | New: renders native `<select>` element                                                 |
 
 ### Filter → DropdownMenu
 
@@ -140,6 +142,20 @@ This document covers changes specific to migrating from IDS v5 (`@iress-oss/ids-
 | `value`       | `selected`          | Prop renamed          |
 | `multiSelect` | `multiSelect`       | Unchanged             |
 | `searchable`  | `searchable`        | Unchanged             |
+
+### Popover
+
+| v5 prop        | v6 prop        | Notes                                                                                                |
+| -------------- | -------------- | ---------------------------------------------------------------------------------------------------- |
+| `contentStyle` | `contentStyle` | Unchanged                                                                                            |
+| —              | —              | ⚠️ **Breaking:** Popover content now has default `padding: spacing.4`. Override with `contentStyle={{ padding: 'spacing.0' }}` if you were providing your own inner padding |
+
+### Readonly
+
+| v5 prop | v6 prop   | Notes                                                                                                |
+| ------- | --------- | ---------------------------------------------------------------------------------------------------- |
+| —       | `actions` | New: array of button props rendered alongside the readonly value (e.g. edit/save toggles)            |
+| —       | —         | ⚠️ **Breaking:** DOM structure changed — inner content is now wrapped in an additional `wrapper` div inside `root`. CSS selectors targeting direct children of the root may need updating |
 
 ## Styling Changes
 

--- a/packages/components/docs/Resources/030-MigrationGuides/v6.mdx
+++ b/packages/components/docs/Resources/030-MigrationGuides/v6.mdx
@@ -84,11 +84,11 @@ SASS modules have been replaced with [Panda CSS](https://panda-css.com/) for typ
 
 ### Autocomplete
 
-| Change                  | Details                                                |
-| ----------------------- | ------------------------------------------------------ |
-| Removed `watermark`     | No longer supported                                    |
-| Hook: `options` required | `options` is now required in `useAutocompleteSearch`  |
-| Hook: `displayResults`  | Removed from hook return                               |
+| Change                   | Details                                              |
+| ------------------------ | ---------------------------------------------------- |
+| Removed `watermark`      | No longer supported                                  |
+| Hook: `options` required | `options` is now required in `useAutocompleteSearch` |
+| Hook: `displayResults`   | Removed from hook return                             |
 
 ### Badge → Pill (renamed)
 
@@ -154,6 +154,7 @@ No changes.
 ### Combobox (removed)
 
 `IressCombobox` and `IressMultiCombobox` have been removed. Use:
+
 - `IressSelect` for restricted selection from options
 - `IressAutocomplete` for free-text input with suggestions
 
@@ -215,14 +216,14 @@ Use the `srOnly` or `hide` styling props available on any component.
 
 ### Icon
 
-| Change                    | Details                                                                                             |
-| ------------------------- | --------------------------------------------------------------------------------------------------- |
-| Removed `mode`            | Use `color` instead                                                                                 |
-| `name` is now type-safe   | IDE autocompletion available                                                                        |
-| Removed `size`            | Inherits font size from parent. Use custom CSS for specific sizes; use `IressImage` for large icons |
-| New `IressIconProvider`   | Required for optimal Material Symbols usage with font subsetting. Already included in `IressProvider` and `IressShadow` — no need to add separately |
-| New `type` prop           | Select icon provider (`'fontawesome'` \| `'material'`)                                              |
-| New `filled` prop         | Material Symbols filled variant                                                                     |
+| Change                  | Details                                                                                                                                             |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Removed `mode`          | Use `color` instead                                                                                                                                 |
+| `name` is now type-safe | IDE autocompletion available                                                                                                                        |
+| Removed `size`          | Inherits font size from parent. Use custom CSS for specific sizes; use `IressImage` for large icons                                                 |
+| New `IressIconProvider` | Required for optimal Material Symbols usage with font subsetting. Already included in `IressProvider` and `IressShadow` — no need to add separately |
+| New `type` prop         | Select icon provider (`'fontawesome'` \| `'material'`)                                                                                              |
+| New `filled` prop       | Material Symbols filled variant                                                                                                                     |
 
 ### Image
 
@@ -230,10 +231,10 @@ New component for displaying responsive images.
 
 ### Inline
 
-| Change          | Details                                                    |
-| --------------- | ---------------------------------------------------------- |
-| `gutter` → `gap`| Accepts the larger spacing token spectrum                  |
-| New `rowGap`    | Set top/bottom gap when content wraps                      |
+| Change           | Details                                   |
+| ---------------- | ----------------------------------------- |
+| `gutter` → `gap` | Accepts the larger spacing token spectrum |
+| New `rowGap`     | Set top/bottom gap when content wraps     |
 
 ### Input
 
@@ -259,16 +260,16 @@ New component for anchor links in text paragraphs. Accepts the same props as `Ir
 
 ### Menu
 
-| Change                            | Details                                                                           |
-| --------------------------------- | --------------------------------------------------------------------------------- |
-| `defaultValue`/`onChange`/`value` | Type-aware based on `multiSelect` — arrays when `true`, single value when `false` |
-| Removed `MenuSelected` interface  | Menu is now generic extending `FormControlValue`                                  |
-| Removed `mapMenuItems`            | Map `IressMenuItem` using arrays directly                                         |
-| Removed `role="nav"`              | Nav styling removed. For navigation menus, use `IressSideNav` pattern or custom styling          |
-| New `radio` variant               | Radio prepend to show selection                                                   |
-| New `subdraw` variant             | Menu groups as popovers                                                           |
-| New `side` variant                | Side menu with collapsible groups                                                 |
-| New `rail` variant                | Blue background, best with icons                                                  |
+| Change                            | Details                                                                                 |
+| --------------------------------- | --------------------------------------------------------------------------------------- |
+| `defaultValue`/`onChange`/`value` | Type-aware based on `multiSelect` — arrays when `true`, single value when `false`       |
+| Removed `MenuSelected` interface  | Menu is now generic extending `FormControlValue`                                        |
+| Removed `mapMenuItems`            | Map `IressMenuItem` using arrays directly                                               |
+| Removed `role="nav"`              | Nav styling removed. For navigation menus, use `IressSideNav` pattern or custom styling |
+| New `radio` variant               | Radio prepend to show selection                                                         |
+| New `subdraw` variant             | Menu groups as popovers                                                                 |
+| New `side` variant                | Side menu with collapsible groups                                                       |
+| New `rail` variant                | Blue background, best with icons                                                        |
 
 ### MenuItem
 
@@ -344,16 +345,17 @@ New component supporting the data colour spectrum with automatic rounded corners
 
 ### Popover
 
-| Change                        | Details                                                                                                    |
-| ----------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| Removed `disabledAutoToggle`  | Use `show`, `onActivated`, and `onDeactivated` for controlled popovers. `ref` is reserved for uncontrolled |
-| Removed `width`               | Use `contentStyle` prop with custom CSS                                                                    |
-| Deprecated `contentClassName` | Use `contentStyle.className`                                                                               |
-| New `contentStyle`            | Customise `className`, `style`, and styling props on the popover content                                   |
-| New `fluid`                   | Full container width                                                                                       |
-| New `offset`                  | Number or object for popover positioning offset (default: 5)                                               |
-| New `nested`                  | Nested navigation behaviour                                                                                |
-| Z-index                       | Now uses z-index for consistent layering                                                                   |
+| Change                        | Details                                                                                                                                                |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Removed `disabledAutoToggle`  | Use `show`, `onActivated`, and `onDeactivated` for controlled popovers. `ref` is reserved for uncontrolled                                             |
+| Removed `width`               | Use `contentStyle` prop with custom CSS                                                                                                                |
+| Deprecated `contentClassName` | Use `contentStyle.className`                                                                                                                           |
+| New `contentStyle`            | Customise `className`, `style`, and styling props on the popover content                                                                               |
+| New `fluid`                   | Full container width                                                                                                                                   |
+| New `offset`                  | Number or object for popover positioning offset (default: 5)                                                                                           |
+| New `nested`                  | Nested navigation behaviour                                                                                                                            |
+| Z-index                       | Now uses z-index for consistent layering                                                                                                               |
+| Default padding               | ⚠️ Content now has `padding: spacing.4` by default. If you were adding your own inner padding, override with `contentStyle={{ padding: 'spacing.0' }}` |
 
 ### Progress
 
@@ -365,13 +367,13 @@ New component supporting the data colour spectrum with automatic rounded corners
 
 ### Provider
 
-| Change                  | Details                                                                      |
-| ----------------------- | ---------------------------------------------------------------------------- |
-| Removed `noIcons`       | Use `noDefaultFont` instead                                                  |
-| Removed `injectPushStyles` | No longer available                                                       |
-| New `noSubsetting`      | Controls automatic font subsetting via Google Fonts CDN for icons            |
-| New `noDefaultFont`     | Controls loading of default Iress font from CDN                              |
-| Icon handling           | Now uses `IressIconProvider` with Material Symbols instead of icon CSS       |
+| Change                     | Details                                                                |
+| -------------------------- | ---------------------------------------------------------------------- |
+| Removed `noIcons`          | Use `noDefaultFont` instead                                            |
+| Removed `injectPushStyles` | No longer available                                                    |
+| New `noSubsetting`         | Controls automatic font subsetting via Google Fonts CDN for icons      |
+| New `noDefaultFont`        | Controls loading of default Iress font from CDN                        |
+| Icon handling              | Now uses `IressIconProvider` with Material Symbols instead of icon CSS |
 
 > **Note:** `IressProvider` already includes `IressModalProvider`, `IressSlideoutProvider`, `IressToasterProvider`, and `IressIconProvider`. You do not need to add these separately. `IressShadow` includes `IressProvider` internally, so no additional providers are needed when using `IressShadow` either.
 
@@ -395,7 +397,11 @@ New component for rendering a standalone radio mark indicator (similar to `Iress
 
 ### Readonly
 
-Styled to match other input text sizes. Use the new `textStyle` prop for larger text (e.g. statistics).
+| Change               | Details                                                                                                                                                              |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Styled to match      | Styled to match other input text sizes. Use the new `textStyle` prop for larger text (e.g. statistics)                                                               |
+| New `actions` prop   | Array of button props rendered alongside the readonly value (e.g. edit/save toggles). Actions passed to `IressInput` in `readOnly` mode are also forwarded           |
+| DOM structure change | ⚠️ Inner content is now wrapped in an additional `wrapper` div inside `root`. CSS selectors targeting direct children of the readonly root element may need updating |
 
 ### RichSelect → Select (renamed)
 
@@ -410,14 +416,16 @@ Styled to match other input text sizes. Use the new `textStyle` prop for larger 
 
 ### Select
 
-| Change                            | Details                                                                                                            |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| Renamed from `IressRichSelect`    | Now uses `LabelValueMeta` via `options`                                                                            |
-| `readonly` → `readOnly`           | —                                                                                                                  |
-| `defaultValue`/`onChange`/`value` | Type-aware based on `multiSelect` — arrays when `true`, single value when `false`                                  |
-| New `native` prop                 | Renders a browser-native select (replaces the old `IressSelect`). Note: still passes `LabelValueMeta` as the value |
-| Grouped items                     | Now supported                                                                                                      |
-| New hover and focus states        | —                                                                                                                  |
+| Change                                 | Details                                                                                                                     |
+| -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| Renamed from `IressRichSelect`         | Now uses `LabelValueMeta` via `options`                                                                                     |
+| `readonly` → `readOnly`                | —                                                                                                                           |
+| `defaultValue`/`onChange`/`value`      | Type-aware based on `multiSelect` — arrays when `true`, single value when `false`                                           |
+| `value`/`defaultValue` accepts strings | Now also accepts a plain string or `FormControlValue` that resolves to the matching option automatically                    |
+| New `multiSelectLimit` prop            | Limits visible selected tags before collapsing to "+N more" summary (default `5`). Display only — does not limit selections |
+| New `native` prop                      | Renders a browser-native select (replaces the old `IressSelect`). Note: still passes `LabelValueMeta` as the value          |
+| Grouped items                          | Now supported                                                                                                               |
+| New hover and focus states             | —                                                                                                                           |
 
 The v5 native `IressSelect` with `children` (option elements) is replaced by `IressSelect` with the `native` prop:
 
@@ -502,13 +510,14 @@ New component for applying IDS styling props to any element or component without
 
 ### TabSet
 
-| Change               | Details                                      |
-| -------------------- | -------------------------------------------- |
-| Removed `mapTabs`    | Use `Array.map` to map objects to `IressTab` |
-| Selected tabs        | Now have a highlighted background            |
-| New `panelStyle`     | Custom style for panel area                  |
-| New `tabHolderStyle` | Custom style for tab holder area             |
-| New `type`           | Tab styling type (`'primary'` \| `'secondary'`) |
+| Change               | Details                                                                                                                                    |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| Removed `mapTabs`    | Use `Array.map` to map objects to `IressTab`                                                                                               |
+| Selected tabs        | Now have a highlighted background                                                                                                          |
+| New `panelStyle`     | Custom style for panel area                                                                                                                |
+| New `tabHolderStyle` | Custom style for tab holder area                                                                                                           |
+| New `type`           | Tab styling type (`'primary'` \| `'secondary'`)                                                                                            |
+| Active indicator     | Now uses `ResizeObserver` and `getBoundingClientRect()` for positioning — correctly updates when tab content changes size or layout shifts |
 
 ### Tag
 
@@ -520,14 +529,14 @@ New component for applying IDS styling props to any element or component without
 
 ### TagInput
 
-| Change                         | Details                                              |
-| ------------------------------ | ---------------------------------------------------- |
-| Removed `testid__input__input` | Use `testid__input` instead                          |
-| Removed `testid__items`        | —                                                    |
-| `onTagDelete` signature        | Now includes event: `(label, e) => void`             |
-| `onTagDeleteAll` signature     | Now includes event: `(label, e) => void`             |
-| New `tagLimit`                 | Limit tags before shortening (default: 5)            |
-| New `selectedOptionsTagText`   | Text for tag count display                           |
+| Change                         | Details                                   |
+| ------------------------------ | ----------------------------------------- |
+| Removed `testid__input__input` | Use `testid__input` instead               |
+| Removed `testid__items`        | —                                         |
+| `onTagDelete` signature        | Now includes event: `(label, e) => void`  |
+| `onTagDeleteAll` signature     | Now includes event: `(label, e) => void`  |
+| New `tagLimit`                 | Limit tags before shortening (default: 5) |
+| New `selectedOptionsTagText`   | Text for tag count display                |
 
 ### Text
 
@@ -570,10 +579,10 @@ New component for applying IDS styling props to any element or component without
 
 ### Tooltip
 
-| Change                       | Details                                                    |
-| ---------------------------- | ---------------------------------------------------------- |
-| `align` prop simplified      | Removed deprecated enum option, now uses string literals   |
-| Removed `IressTooltip.Align` | Use string values directly                                 |
+| Change                       | Details                                                  |
+| ---------------------------- | -------------------------------------------------------- |
+| `align` prop simplified      | Removed deprecated enum option, now uses string literals |
+| Removed `IressTooltip.Align` | Use string values directly                               |
 
 ### ValidationLink
 


### PR DESCRIPTION
This pull request updates migration and reference documentation for IDS v6 components, focusing on clarifying breaking changes, new features, and API modifications. The most significant updates are centered around the `IressSelect`, `IressPopover`, and `IressReadonly` components, highlighting new props, changes in accepted value types, and structural changes that affect CSS targeting. These improvements help developers transition more smoothly from v5 to v6 by providing explicit guidance on handling common migration issues.

**Component API and Feature Changes**

* [`IressSelect`](diffhunk://#diff-f4474644b7b02248ef727edc4c6bd51c9481a6598d3ee9d4e174918699657f1bL127-R133): Now accepts both plain strings and `LabelValueMeta` objects for `value` and `defaultValue` props, making selection more flexible. Added new `multiSelectLimit` and `native` props, and clarified grouped item support and hover/focus states. [[1]](diffhunk://#diff-f4474644b7b02248ef727edc4c6bd51c9481a6598d3ee9d4e174918699657f1bL127-R133) [[2]](diffhunk://#diff-f4474644b7b02248ef727edc4c6bd51c9481a6598d3ee9d4e174918699657f1bR146-R159) [[3]](diffhunk://#diff-914ea05cdf29b93080b99eb4d9997b7ec33fdf47c36919810735b5a552f5bbd6L414-R425)
* [`IressPopover`](diffhunk://#diff-d02184747f3be3b9a802b940d0978bb84bbb1c2bb26cc975706d9056dc79d2c3R74-R76): Popover content now has default padding (`spacing.4`), which may require overriding if custom inner padding was previously used. This is a breaking change and is documented with guidance for overrides. [[1]](diffhunk://#diff-d02184747f3be3b9a802b940d0978bb84bbb1c2bb26cc975706d9056dc79d2c3R74-R76) [[2]](diffhunk://#diff-f4474644b7b02248ef727edc4c6bd51c9481a6598d3ee9d4e174918699657f1bR146-R159) [[3]](diffhunk://#diff-914ea05cdf29b93080b99eb4d9997b7ec33fdf47c36919810735b5a552f5bbd6L348-R349) [[4]](diffhunk://#diff-914ea05cdf29b93080b99eb4d9997b7ec33fdf47c36919810735b5a552f5bbd6R358)
* [`IressReadonly`](diffhunk://#diff-fde38497d43c0d12f834dc8442ebfa2642b87ae250e4820f168875c938600a99L28-R28): Introduced a new `actions` prop for inline action buttons (e.g., edit/save toggles), and changed the DOM structure by wrapping inner content in a `wrapper` div inside `root`, affecting CSS selectors. [[1]](diffhunk://#diff-fde38497d43c0d12f834dc8442ebfa2642b87ae250e4820f168875c938600a99L28-R28) [[2]](diffhunk://#diff-6898a871ec0855500054a395741f096b256d04070c22956c53f05a93de501aa4L87-R87) [[3]](diffhunk://#diff-d02184747f3be3b9a802b940d0978bb84bbb1c2bb26cc975706d9056dc79d2c3R74-R76) [[4]](diffhunk://#diff-f4474644b7b02248ef727edc4c6bd51c9481a6598d3ee9d4e174918699657f1bR146-R159) [[5]](diffhunk://#diff-914ea05cdf29b93080b99eb4d9997b7ec33fdf47c36919810735b5a552f5bbd6L398-R404)

**Migration Guidance and Common Gotchas**

* Added explicit migration notes and common pitfalls for `IressSelect`, `IressPopover`, and `IressReadonly`, including API changes, value handling, and CSS selector updates. [[1]](diffhunk://#diff-d02184747f3be3b9a802b940d0978bb84bbb1c2bb26cc975706d9056dc79d2c3R74-R76) [[2]](diffhunk://#diff-f4474644b7b02248ef727edc4c6bd51c9481a6598d3ee9d4e174918699657f1bL127-R133) [[3]](diffhunk://#diff-f4474644b7b02248ef727edc4c6bd51c9481a6598d3ee9d4e174918699657f1bR146-R159) [[4]](diffhunk://#diff-914ea05cdf29b93080b99eb4d9997b7ec33fdf47c36919810735b5a552f5bbd6L398-R404)

**Documentation Consistency and Formatting**

* Improved formatting and consistency across migration guides, including updated tables, clearer descriptions, and expanded details for new and changed props. [[1]](diffhunk://#diff-914ea05cdf29b93080b99eb4d9997b7ec33fdf47c36919810735b5a552f5bbd6L88-R88) [[2]](diffhunk://#diff-914ea05cdf29b93080b99eb4d9997b7ec33fdf47c36919810735b5a552f5bbd6R157) [[3]](diffhunk://#diff-914ea05cdf29b93080b99eb4d9997b7ec33fdf47c36919810735b5a552f5bbd6L219-R220) [[4]](diffhunk://#diff-914ea05cdf29b93080b99eb4d9997b7ec33fdf47c36919810735b5a552f5bbd6L234-R235) [[5]](diffhunk://#diff-914ea05cdf29b93080b99eb4d9997b7ec33fdf47c36919810735b5a552f5bbd6L263-R264) [[6]](diffhunk://#diff-914ea05cdf29b93080b99eb4d9997b7ec33fdf47c36919810735b5a552f5bbd6L369-R371) [[7]](diffhunk://#diff-914ea05cdf29b93080b99eb4d9997b7ec33fdf47c36919810735b5a552f5bbd6L506-R520) [[8]](diffhunk://#diff-914ea05cdf29b93080b99eb4d9997b7ec33fdf47c36919810735b5a552f5bbd6L524-R533) [[9]](diffhunk://#diff-914ea05cdf29b93080b99eb4d9997b7ec33fdf47c36919810735b5a552f5bbd6L574-R583)

These updates collectively provide clearer, more actionable guidance for migrating to IDS v6, reducing friction and potential errors for developers.