### PR TITLE
fix(alpha): Shadow - ensure IressShadowProps includes necessary IressProviderProps

### DIFF
--- a/packages/components/src/patterns/Shadow/Shadow.tsx
+++ b/packages/components/src/patterns/Shadow/Shadow.tsx
@@ -10,10 +10,13 @@ import { createPortal } from 'react-dom';
 import idsCss from '../../styled-system/styles.css?raw';
 import { defaultFonts } from '@iress-oss/ids-tokens';
 import { type IressUnstyledProps } from '@/types';
-import { IressProvider } from '@/components/Provider';
+import { IressProvider, type IressProviderProps } from '@/components/Provider';
 import { getNonce } from '@helpers/dom/getNonce';
 
-export interface IressShadowProps extends IressUnstyledProps {
+export interface IressShadowProps
+  extends
+    IressUnstyledProps,
+    Pick<IressProviderProps, 'noIconProvider' | 'noSubsetting' | 'position'> {
   /**
    * Children to be rendered inside the shadow DOM
    */
@@ -49,6 +52,9 @@ export const IressShadow = forwardRef<ShadowRoot | null, IressShadowProps>(
     {
       children,
       fontFaceUrls = [...defaultFonts],
+      noIconProvider,
+      noSubsetting,
+      position,
       stylesheetContents = {},
       stylesheetUrls = [],
       ...restProps
@@ -131,7 +137,13 @@ export const IressShadow = forwardRef<ShadowRoot | null, IressShadowProps>(
 
     return (
       <div ref={hostRef} {...restProps}>
-        <IressProvider container={containerRef} noDefaultFont>
+        <IressProvider
+          container={containerRef}
+          noDefaultFont
+          noIconProvider={noIconProvider}
+          noSubsetting={noSubsetting}
+          position={position}
+        >
           {shadowRoot && createPortal(children, shadowRoot)}
         </IressProvider>
       </div>


### PR DESCRIPTION
This pull request updates the `IressShadow` component to allow additional configuration options to be passed down to the underlying `IressProvider`. The main changes involve extending the component's props and ensuring these new options are forwarded correctly.

Enhancements to prop handling and provider configuration:

* The `IressShadowProps` interface now extends selected props (`noIconProvider`, `noSubsetting`, and `position`) from `IressProviderProps`, allowing these options to be set directly on `IressShadow`.
* The `IressShadow` component now accepts and forwards `noIconProvider`, `noSubsetting`, and `position` props to the underlying `IressProvider`, enabling more granular control over its behavior from the parent component. [[1]](diffhunk://#diff-a19e56e0ca39e2821d3bf75ce83c48578f5b1046ebd0fa63aa18c977e3c1d9caR55-R57) [[2]](diffhunk://#diff-a19e56e0ca39e2821d3bf75ce83c48578f5b1046ebd0fa63aa18c977e3c1d9caL134-R146)