### PR TITLE
docs: update Figma MCP setup instructions in SKILL.md and README.md for improved clarity

### DIFF
--- a/.agents/skills/figma-to-ids/SKILL.md
+++ b/.agents/skills/figma-to-ids/SKILL.md
@@ -18,6 +18,47 @@ metadata:
 
 Translate Figma design properties and structures into IDS (Iress Design System) component implementations. This skill helps AI agents interpret Figma design metadata (from tools like Figma MCP or exported design specs) and produce accurate IDS code.
 
+## Figma MCP Setup
+
+AI agents need a Figma MCP server to read Figma files directly. Without one, you can still use this skill by pasting exported design specs or Figma component descriptions manually.
+
+### Setup
+
+1. **Get a Figma personal access token** — In Figma, go to *Settings → Account → Personal access tokens* and create a token with **File content (Read-only)** scope.
+
+2. **Add the MCP server to your agent config.** The exact location depends on your tool:
+
+   | Tool | Config file |
+   | --- | --- |
+   | **Kiro CLI** | `~/.kiro/settings/mcp.json` (global) or `.kiro/settings/mcp.json` (workspace) |
+   | **Cursor** | `.cursor/mcp.json` |
+   | **Claude Code** | `.claude/mcp.json` or `~/.claude/mcp.json` |
+   | **VS Code (GitHub Copilot)** | `.vscode/mcp.json` |
+
+   Example configuration (using the community [`figma-developer-mcp`](https://github.com/nicholasgriffintn/figma-developer-mcp) server):
+
+   ```json
+   {
+     "mcpServers": {
+       "Figma": {
+         "command": "npx",
+         "args": ["-y", "figma-developer-mcp", "--stdio"],
+         "env": {
+           "FIGMA_API_KEY": "<your-figma-token>"
+         }
+       }
+     }
+   }
+   ```
+
+   For Kiro CLI, you can also add it via the command line:
+
+   ```bash
+   kiro-cli mcp add --name Figma --command npx --args "-y figma-developer-mcp --stdio" --env "FIGMA_API_KEY=<your-figma-token>"
+   ```
+
+3. **Verify** — Ask your agent to fetch data from a Figma file URL. It should return frame and component information.
+
 ## Process
 
 1. **Analyse Figma structure** — Identify frames, auto-layout, and component instances

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ This repository provides **agent skills** that give AI coding assistants context
 
 ### Figma Integration
 
-AI agents need a Figma MCP server to read Figma files directly. See the [figma-to-ids skill](.agents/skills/figma-to-ids/SKILL.md#figma-mcp-setup) for setup instructions covering Kiro CLI, Cursor, Claude Code, and VS Code.
+A Figma MCP server is only required if you want AI agents to read Figma files directly. The `figma-to-ids` skill can still be used without MCP by pasting exported specs or other design metadata into your prompt. See the [figma-to-ids skill](.agents/skills/figma-to-ids/SKILL.md#figma-mcp-setup) for setup instructions covering Kiro CLI, Cursor, Claude Code, and VS Code.
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ This repository provides **agent skills** that give AI coding assistants context
 | `ui-translation`    | Translate natural language UI descriptions into IDS component code     |
 | `version-migration` | Migrate applications between IDS major versions (v4→v5, v5→v6, OUI→v6)|
 
+### Figma Integration
+
+AI agents need a Figma MCP server to read Figma files directly. See the [figma-to-ids skill](.agents/skills/figma-to-ids/SKILL.md#figma-mcp-setup) for setup instructions covering Kiro CLI, Cursor, Claude Code, and VS Code.
+
 ### Installation
 
 Install skills using the [skills CLI](https://github.com/vercel-labs/skills):


### PR DESCRIPTION
This pull request improves the documentation for integrating Figma with AI agent skills by adding detailed setup instructions for connecting to Figma via an MCP server. The main changes clarify the requirements and provide step-by-step guidance for configuring various development tools.

Figma integration documentation:

* [`.agents/skills/figma-to-ids/SKILL.md`](diffhunk://#diff-776195fe2c2ab077bc54723100aed2223f13be3ec39c1bad336e99ddd4a22dc7R21-R61): Added a new "Figma MCP Setup" section with instructions on obtaining a Figma personal access token, configuring the MCP server for different tools (Kiro CLI, Cursor, Claude Code, VS Code), and verifying the connection. Example configuration files and command-line usage are included.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R91-R94): Added a "Figma Integration" subsection referencing the new setup instructions, making it clear how to enable Figma file reading for AI agents.