### PR TITLE
fix(v6): IressStack - update margin rule to exclude ids-field-group class

### DIFF
--- a/packages/components/src/components/Stack/Stack.styles.ts
+++ b/packages/components/src/components/Stack/Stack.styles.ts
@@ -4,7 +4,7 @@ export const stack = cva({
   base: {
     display: 'flex',
     flexDirection: 'column',
-    '& > :not(.ids-field)': {
+    '& > :not(.ids-field, .ids-field-group)': {
       marginBlock: 'spacing.0', // If you stick it in a stack, you should be using gap instead of margin to space the items inside the stack
     },
   },


### PR DESCRIPTION
This pull request makes a small but important update to the styling logic in the `Stack` component. The change ensures that both `.ids-field` and `.ids-field-group` elements are excluded from the default margin reset applied to stack children.

- Updated the `stack` style in `Stack.styles.ts` so that elements with the `.ids-field-group` class, in addition to `.ids-field`, are not targeted by the margin reset rule.