### PR TITLE
chore: beta increment release

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iress-oss/ids-components",
-  "version": "6.0.0-beta.5",
+  "version": "6.0.0-beta.6",
   "description": "Iress React Component Library",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -31,8 +31,8 @@
     "typecheck:node": "tsc --noEmit -p tsconfig.node.json"
   },
   "devDependencies": {
-    "@iress-oss/ids-theme-preset": "^6.0.0-beta.1",
-    "@iress-oss/ids-tokens": "^6.0.0-beta.1",
+    "@iress-oss/ids-theme-preset": "^6.0.0-beta.2",
+    "@iress-oss/ids-tokens": "^6.0.0-beta.2",
     "@pandacss/dev": "1.9.1",
     "@testing-library/dom": "10.4.1",
     "@testing-library/jest-dom": "6.9.1",

--- a/packages/theme-preset/package.json
+++ b/packages/theme-preset/package.json
@@ -42,7 +42,7 @@
     "typecheck": "tsc --noEmit -p tsconfig.lib.json"
   },
   "dependencies": {
-    "@iress-oss/ids-tokens": "^6.0.0-beta.1"
+    "@iress-oss/ids-tokens": "^6.0.0-beta.2"
   },
   "peerDependencies": {
     "@pandacss/dev": ">=1.8.0",

--- a/packages/theme-preset/package.json
+++ b/packages/theme-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iress-oss/ids-theme-preset",
-  "version": "6.0.0-beta.1",
+  "version": "6.0.0-beta.2",
   "description": "Panda CSS preset for the Iress Design System",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iress-oss/ids-tokens",
-  "version": "6.0.0-beta.1",
+  "version": "6.0.0-beta.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1340,8 +1340,8 @@ __metadata:
   dependencies:
     "@floating-ui/react": "npm:0.27.19"
     "@fortawesome/fontawesome-common-types": "npm:0.2.36"
-    "@iress-oss/ids-theme-preset": "npm:^6.0.0-beta.1"
-    "@iress-oss/ids-tokens": "npm:^6.0.0-beta.1"
+    "@iress-oss/ids-theme-preset": "npm:^6.0.0-beta.2"
+    "@iress-oss/ids-tokens": "npm:^6.0.0-beta.2"
     "@pandacss/dev": "npm:1.9.1"
     "@tanstack/react-table": "npm:8.21.3"
     "@testing-library/dom": "npm:10.4.1"
@@ -1625,11 +1625,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@iress-oss/ids-theme-preset@npm:^6.0.0-beta.1, @iress-oss/ids-theme-preset@workspace:packages/theme-preset":
+"@iress-oss/ids-theme-preset@npm:^6.0.0-beta.2, @iress-oss/ids-theme-preset@workspace:packages/theme-preset":
   version: 0.0.0-use.local
   resolution: "@iress-oss/ids-theme-preset@workspace:packages/theme-preset"
   dependencies:
-    "@iress-oss/ids-tokens": "npm:^6.0.0-beta.1"
+    "@iress-oss/ids-tokens": "npm:^6.0.0-beta.2"
     "@pandacss/dev": "npm:1.9.1"
     "@pandacss/types": "npm:1.9.1"
     "@typescript-eslint/eslint-plugin": "npm:^8.58.0"
@@ -1651,7 +1651,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@iress-oss/ids-tokens@npm:^6.0.0-beta.1, @iress-oss/ids-tokens@workspace:packages/tokens":
+"@iress-oss/ids-tokens@npm:^6.0.0-beta.1, @iress-oss/ids-tokens@npm:^6.0.0-beta.2, @iress-oss/ids-tokens@workspace:packages/tokens":
   version: 0.0.0-use.local
   resolution: "@iress-oss/ids-tokens@workspace:packages/tokens"
   dependencies:


### PR DESCRIPTION
## Summary

Bumps beta versions for all core packages:

| Package | From | To |
|---|---|---|
| `@iress-oss/ids-components` | `6.0.0-beta.5` | `6.0.0-beta.6` |
| `@iress-oss/ids-tokens` | `6.0.0-beta.1` | `6.0.0-beta.2` |
| `@iress-oss/ids-theme-preset` | `6.0.0-beta.1` | `6.0.0-beta.2` |

## Release process

Once merged to `main`, CI will detect the version bump and auto-publish to npm with the `beta` tag.

⏳ ~2 hour delay before packages appear in the private npm registry.