### PR TITLE
feat(v6): IressTable - add row virtualisation support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,9 @@ ESLint 10 with flat config. Key rules:
 - TypeScript strict, single quotes, semicolons, trailing commas (`all`), 2-space indent
 - LF line endings, UTF-8
 - Markdown/MDX: 80 char line length
+- Mock/example components (in `mocks/` dirs, used by Storybook stories) must NOT use `styled` from `@/styled-system/jsx` — use plain HTML elements with inline styles or CSS classes instead. `styled` is an internal implementation detail not exposed to consumers.
+- Mock/example components must import IDS components from `@/main` (e.g. `import { IressButton } from '@/main'`). The build replaces `@/main` with `@iress-oss/ids-components` in displayed source examples.
+- Styling should be in CSS (recipes/styles files) where possible, not inline styles. Inline styles are a last resort for truly dynamic values (e.g. user-provided dimensions).
 - See `.prettierrc.cjs` and `.editorconfig` for full config
 
 ## Monorepo structure

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^5.1.1",
-    "@iress-oss/ids-components": "^6.0.0-beta.3",
+    "@iress-oss/ids-components": "^6.0.0-beta.7",
     "@iress-oss/ids-storybook-config": "^0.6.0",
     "@iress-oss/ids-storybook-okta": "^0.1.2",
     "@iress-oss/ids-storybook-sandbox": "^0.2.2",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iress-oss/ids-components",
-  "version": "6.0.0-beta.6",
+  "version": "6.0.0-beta.7",
   "description": "Iress React Component Library",
   "license": "Apache-2.0",
   "type": "module",
@@ -31,7 +31,7 @@
     "typecheck:node": "tsc --noEmit -p tsconfig.node.json"
   },
   "devDependencies": {
-    "@iress-oss/ids-theme-preset": "^6.0.0-beta.2",
+    "@iress-oss/ids-theme-preset": "^6.0.0-beta.3",
     "@iress-oss/ids-tokens": "^6.0.0-beta.2",
     "@pandacss/dev": "1.9.1",
     "@testing-library/dom": "10.4.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -78,6 +78,7 @@
     "@floating-ui/react": "0.27.19",
     "@fortawesome/fontawesome-common-types": "0.2.36",
     "@tanstack/react-table": "8.21.3",
+    "@tanstack/react-virtual": "3.13.2",
     "@types/mdx": "^2.0.13",
     "fuzzysort": "3.1.0",
     "material-symbols": "0.44.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -78,7 +78,7 @@
     "@floating-ui/react": "0.27.19",
     "@fortawesome/fontawesome-common-types": "0.2.36",
     "@tanstack/react-table": "8.21.3",
-    "@tanstack/react-virtual": "3.13.2",
+    "@tanstack/react-virtual": "3.13.12",
     "@types/mdx": "^2.0.13",
     "fuzzysort": "3.1.0",
     "material-symbols": "0.44.1",

--- a/packages/components/src/components/CheckboxGroup/mocks/CheckboxGroupTable.tsx
+++ b/packages/components/src/components/CheckboxGroup/mocks/CheckboxGroupTable.tsx
@@ -39,6 +39,7 @@ export const CheckboxGroupTable = () => (
         label="Let them eat cake"
         name="let-them-eat-cake"
         hiddenLabel
+        mb="none"
         rules={{ required: 'Please select a cake' }}
         render={(field) => (
           <IressCheckboxGroup {...field} layout="stack">
@@ -78,7 +79,7 @@ export const CheckboxGroupTable = () => (
           </IressCheckboxGroup>
         )}
       />
-      <IressButton type="submit" mode="primary">
+      <IressButton type="submit" mode="primary" alignSelf="start">
         Submit
       </IressButton>
     </IressStack>

--- a/packages/components/src/components/Table/Table.docs.mdx
+++ b/packages/components/src/components/Table/Table.docs.mdx
@@ -259,6 +259,34 @@ The `compact` prop can be used to reduce the padding around the table cells and 
 
 <ComponentExample of={ComponentStories.Compact} />
 
+### Virtualisation
+
+For tables with large datasets (hundreds or thousands of rows), virtualisation
+renders only the visible rows to the DOM. This eliminates UI freezes during
+bulk state updates and keeps scrolling smooth.
+
+Enable it with the `virtualise` prop. The `virtualise` prop accepts `true` for defaults, or an options object:
+
+| Option         | Type               | Default | Description                                      |
+| -------------- | ------------------ | ------- | ------------------------------------------------ |
+| `height`       | `number \| string` | `400`   | Height of the scroll container (px or CSS value) |
+| `overscan`     | `number`           | `5`     | Extra rows rendered above/below the viewport     |
+| `estimateSize` | `number`           | `40`    | Estimated row height in pixels                   |
+
+**Requirements:**
+
+- The table container must have a bounded height (set via `height` option or
+  CSS on a parent). Without a fixed height, the browser cannot determine which
+  rows are visible.
+- Specify `width` on each column for stable column sizing. Without explicit
+  widths, columns may shift as rows with different content lengths scroll in
+  and out of view.
+- Sorting and filtering work normally with virtualisation enabled.
+- Screen readers announce the correct row position via `aria-rowcount` and
+  `aria-rowindex`.
+
+<ComponentExample of={ComponentStories.Virtualised} />
+
 ## `IressTableBody`
 
 In some cases you may have a table with multiple groups of rows inside it, however the columns are the same. For these cases, you can use the `IressTableBody` component.

--- a/packages/components/src/components/Table/Table.stories.tsx
+++ b/packages/components/src/components/Table/Table.stories.tsx
@@ -13,6 +13,8 @@ import { TableSorting } from './mocks/TableSorting';
 import TableSortingSource from './mocks/TableSorting.tsx?raw';
 import { TableSortingFn } from './mocks/TableSortingFn';
 import TableSortingFnSource from './mocks/TableSortingFn.tsx?raw';
+import { TableVirtualised } from './mocks/TableVirtualised';
+import TableVirtualisedSource from './mocks/TableVirtualised.tsx?raw';
 import { type Row } from '@tanstack/react-table';
 import {
   withJsxTransformer,
@@ -396,5 +398,16 @@ export const Compact: Story = {
           ? 'colour.data.subtle.30'
           : undefined,
     }),
+  },
+};
+
+export const Virtualised: Story = {
+  args: {},
+  argTypes: {
+    ...disableArgTypes(['caption', 'rows', 'columns']),
+  },
+  render: () => <TableVirtualised />,
+  parameters: {
+    ...withTransformedRawSource(TableVirtualisedSource, 'Props'),
   },
 };

--- a/packages/components/src/components/Table/Table.test.tsx
+++ b/packages/components/src/components/Table/Table.test.tsx
@@ -298,6 +298,28 @@ describe('IressTable', () => {
       initialRect: { width: 800, height: 400 },
     };
 
+    beforeAll(() => {
+      Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+        configurable: true,
+        get: () => 400,
+      });
+      Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+        configurable: true,
+        get: () => 800,
+      });
+    });
+
+    afterAll(() => {
+      Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+        configurable: true,
+        get: () => 0,
+      });
+      Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+        configurable: true,
+        get: () => 0,
+      });
+    });
+
     it('renders only a subset of rows when virtualise is enabled', () => {
       const screen = renderComponent({
         rows: LARGE_ROWS,

--- a/packages/components/src/components/Table/Table.test.tsx
+++ b/packages/components/src/components/Table/Table.test.tsx
@@ -285,4 +285,117 @@ describe('IressTable', () => {
       expect(results).toHaveNoViolations();
     });
   });
+
+  describe('virtualise', () => {
+    const LARGE_ROWS = Array.from({ length: 300 }, (_, i) => ({
+      key: `${i}`,
+      value: `row-${i}`,
+    }));
+
+    const virtualiseWithRect = {
+      overscan: 5,
+      estimateSize: 40,
+      initialRect: { width: 800, height: 400 },
+    };
+
+    it('renders only a subset of rows when virtualise is enabled', () => {
+      const screen = renderComponent({
+        rows: LARGE_ROWS,
+        virtualise: virtualiseWithRect,
+      });
+
+      const renderedRows = screen.queryAllByTestId(`${TEST_ID}__row`);
+      expect(renderedRows.length).toBeGreaterThan(0);
+      expect(renderedRows.length).toBeLessThan(LARGE_ROWS.length);
+    });
+
+    it('sets aria-rowcount on the table element', () => {
+      const screen = renderComponent({
+        rows: LARGE_ROWS,
+        virtualise: virtualiseWithRect,
+      });
+
+      const tableEl = screen.getByTestId(`${TEST_ID}__table`);
+      expect(tableEl).toHaveAttribute(
+        'aria-rowcount',
+        String(LARGE_ROWS.length),
+      );
+    });
+
+    it('sets aria-rowindex on each visible row', () => {
+      const screen = renderComponent({
+        rows: LARGE_ROWS,
+        virtualise: virtualiseWithRect,
+      });
+
+      const renderedRows = screen.queryAllByTestId(`${TEST_ID}__row`);
+      expect(renderedRows.length).toBeGreaterThan(0);
+      renderedRows.forEach((row) => {
+        expect(row).toHaveAttribute('aria-rowindex');
+      });
+    });
+
+    it('does not set aria-rowcount when virtualise is not enabled', () => {
+      const screen = renderComponent({ rows: TEST_ROWS });
+
+      const tableEl = screen.getByTestId(`${TEST_ID}__table`);
+      expect(tableEl).not.toHaveAttribute('aria-rowcount');
+    });
+
+    it('renders all rows when virtualise is not enabled', () => {
+      const screen = renderComponent({ rows: TEST_ROWS });
+
+      const renderedRows = screen.getAllByTestId(`${TEST_ID}__row`);
+      expect(renderedRows.length).toBe(TEST_ROWS.length);
+    });
+
+    it('accepts virtualise options with custom overscan', () => {
+      const screen = renderComponent({
+        rows: LARGE_ROWS,
+        virtualise: { ...virtualiseWithRect, overscan: 10 },
+      });
+
+      const renderedRows = screen.queryAllByTestId(`${TEST_ID}__row`);
+      expect(renderedRows.length).toBeGreaterThan(0);
+      expect(renderedRows.length).toBeLessThan(LARGE_ROWS.length);
+    });
+
+    it('does not break when sorting with virtualise enabled', async () => {
+      const screen = renderComponent({
+        rows: LARGE_ROWS,
+        columns: [
+          { key: 'key', label: 'Key', sort: true },
+          { key: 'value', label: 'Value' },
+        ],
+        virtualise: virtualiseWithRect,
+      });
+
+      const sortButton = screen.getByRole('button', { name: 'Keysortable' });
+      await userEvent.click(sortButton);
+
+      // Sorting should not throw or remove the table
+      expect(screen.getByRole('table')).toBeInTheDocument();
+    });
+
+    it('does not break when filtering with virtualise enabled', async () => {
+      const filterRows = Array.from({ length: 50 }, (_, i) => ({
+        key: `${i}`,
+        value: `row-${i}`,
+      }));
+      const screen = renderComponent({
+        rows: filterRows,
+        columns: [
+          { key: 'key', label: 'Key', filter: true },
+          { key: 'value', label: 'Value' },
+        ],
+        virtualise: virtualiseWithRect,
+      });
+
+      await userEvent.click(screen.getByRole('button', { name: 'filterable' }));
+      await userEvent.click(screen.getByRole('option', { name: '0' }));
+
+      // Filtering should not throw or remove the table
+      expect(screen.getByRole('table')).toBeInTheDocument();
+    });
+  });
 });

--- a/packages/components/src/components/Table/Table.tsx
+++ b/packages/components/src/components/Table/Table.tsx
@@ -151,9 +151,14 @@ export const IressTable = <TRow extends object = never, TVal = never>({
   const hasContent = (empty && columns?.length) ?? !!rows?.length;
   const showTable = children ?? hasContent;
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const tableElRef = useRef<HTMLTableElement | null>(null);
+  const theadElRef = useRef<HTMLElement | null>(null);
+  // Force re-render so virtualizer picks up scrollContainerRef
   const [, setScrollReady] = useState(false);
   const scrollCallbackRef = useCallback((node: HTMLDivElement | null) => {
     scrollContainerRef.current = node;
+    tableElRef.current = node?.querySelector('table') ?? null;
+    theadElRef.current = node?.querySelector('thead') ?? null;
     setScrollReady(!!node);
   }, []);
 
@@ -175,15 +180,13 @@ export const IressTable = <TRow extends object = never, TVal = never>({
       typeof virtualise === 'object' ? virtualise.height : undefined;
     const height =
       typeof rawHeight === 'number' ? `${rawHeight}px` : (rawHeight ?? '400px');
-    return { height, maxHeight: '100%' };
+    return { height };
   }, [virtualise]);
 
   const handleScroll = useCallback((e: UIEvent<HTMLDivElement>) => {
     const el = e.currentTarget;
-    const tableEl = el.querySelector('table');
-    const theadEl = el.querySelector('thead');
-    const offset = tableEl?.offsetTop
-      ? tableEl?.offsetTop - (theadEl?.offsetHeight ?? 0)
+    const offset = tableElRef.current?.offsetTop
+      ? tableElRef.current.offsetTop - (theadElRef.current?.offsetHeight ?? 0)
       : 0;
     if (el.scrollTop > offset) {
       el.setAttribute('data-scrolled', '');

--- a/packages/components/src/components/Table/Table.tsx
+++ b/packages/components/src/components/Table/Table.tsx
@@ -4,13 +4,41 @@ import { propagateTestid } from '@helpers/utility/propagateTestid';
 import { TableHeader } from './components/TableHeader';
 import { TableProvider } from './TableProvider';
 import { TableRows, type TableRowsProps } from './components/TableRows';
-import { type ReactNode } from 'react';
+import { type ReactNode, useRef, useState, useCallback, useMemo } from 'react';
 import { table } from './Table.styles';
 import { cx } from '@/styled-system/css';
 import { styled } from '@/styled-system/jsx';
 import { type TableColumn } from './helpers/composeTableColumnDefs';
 import { type IressStyledProps } from '@/types';
 import { GlobalCSSClass } from '@/enums';
+
+export interface TableVirtualiseOptions {
+  /**
+   * Number of rows to render above and below the visible area.
+   * @default 5
+   */
+  overscan?: number;
+
+  /**
+   * Estimated row height in pixels. Used for scroll calculations.
+   * @default 40
+   */
+  estimateSize?: number;
+
+  /**
+   * Height of the scroll container in pixels or CSS value.
+   * Required for virtualisation to work — the container must have a bounded height.
+   * @default 400
+   */
+  height?: number | string;
+
+  /**
+   * Initial rect of the scroll container. Useful for SSR or testing environments
+   * where the scroll container has no layout dimensions.
+   * @internal
+   */
+  initialRect?: { width: number; height: number };
+}
 
 export type IressTableProps<
   TRow extends object = never,
@@ -89,6 +117,13 @@ export type IressTableProps<
    * @default 'row'
    */
   scope?: 'row' | 'col';
+
+  /**
+   * Enable row virtualisation for large datasets. Only visible rows (plus overscan)
+   * are rendered to the DOM. Requires a fixed height on the table container.
+   * Pass `true` for defaults, or an options object to configure.
+   */
+  virtualise?: boolean | TableVirtualiseOptions;
 };
 
 export const IressTable = <TRow extends object = never, TVal = never>({
@@ -107,12 +142,19 @@ export const IressTable = <TRow extends object = never, TVal = never>({
   rowProps,
   rows = [],
   scope,
+  virtualise,
   ...restProps
 }: IressTableProps<TRow, TVal>) => {
   const id = useIdIfNeeded({ id: restProps.id });
   const captionId = `${id}--caption`;
   const hasContent = (empty && columns?.length) ?? !!rows?.length;
   const showTable = children ?? hasContent;
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const [, setScrollReady] = useState(false);
+  const scrollCallbackRef = useCallback((node: HTMLDivElement | null) => {
+    scrollContainerRef.current = node;
+    setScrollReady(!!node);
+  }, []);
 
   const classes = table({
     alternate,
@@ -120,23 +162,54 @@ export const IressTable = <TRow extends object = never, TVal = never>({
     hover,
     hiddenCaption,
     removeRowBorders,
+    virtualise: !!virtualise,
   });
 
   const theadTestId = propagateTestid(dataTestId, 'thead');
   const tbodyTestId = propagateTestid(dataTestId, 'tbody');
+
+  const scrollContainerStyle = useMemo(() => {
+    if (!virtualise) return undefined;
+    const rawHeight =
+      typeof virtualise === 'object' ? virtualise.height : undefined;
+    const height =
+      typeof rawHeight === 'number' ? `${rawHeight}px` : (rawHeight ?? '400px');
+    return { height, maxHeight: '100%' };
+  }, [virtualise]);
+
+  const handleScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
+    const el = e.currentTarget;
+    const tableEl = el.querySelector('table');
+    const theadEl = el.querySelector('thead');
+    const offset = tableEl?.offsetTop
+      ? tableEl?.offsetTop - (theadEl?.offsetHeight ?? 0)
+      : 0;
+    if (el.scrollTop > offset) {
+      el.setAttribute('data-scrolled', '');
+    } else {
+      el.removeAttribute('data-scrolled');
+    }
+  }, []);
 
   if (!showTable) {
     return null;
   }
 
   return (
-    <div className={classes.root} data-testid={dataTestId}>
+    <div
+      className={classes.root}
+      data-testid={dataTestId}
+      ref={virtualise ? scrollCallbackRef : undefined}
+      style={scrollContainerStyle}
+      onScroll={virtualise ? handleScroll : undefined}
+    >
       <TableProvider columns={columns} rows={rows}>
         <styled.table
           {...restProps}
           className={cx(className, classes.table, GlobalCSSClass.Table)}
           id={id}
           data-testid={propagateTestid(dataTestId, 'table')}
+          aria-rowcount={virtualise ? rows.length : undefined}
         >
           <caption
             id={captionId}
@@ -158,6 +231,8 @@ export const IressTable = <TRow extends object = never, TVal = never>({
                 rowProps={rowProps}
                 scope={scope}
                 hiddenHeader={hiddenHeader}
+                virtualise={virtualise}
+                scrollContainerRef={scrollContainerRef}
               />
               <TableEmpty>{empty}</TableEmpty>
             </tbody>

--- a/packages/components/src/components/Table/Table.tsx
+++ b/packages/components/src/components/Table/Table.tsx
@@ -11,6 +11,7 @@ import { styled } from '@/styled-system/jsx';
 import { type TableColumn } from './helpers/composeTableColumnDefs';
 import { type IressStyledProps } from '@/types';
 import { GlobalCSSClass } from '@/enums';
+import type { UIEvent } from 'react';
 
 export interface TableVirtualiseOptions {
   /**
@@ -177,7 +178,7 @@ export const IressTable = <TRow extends object = never, TVal = never>({
     return { height, maxHeight: '100%' };
   }, [virtualise]);
 
-  const handleScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
+  const handleScroll = useCallback((e: UIEvent<HTMLDivElement>) => {
     const el = e.currentTarget;
     const tableEl = el.querySelector('table');
     const theadEl = el.querySelector('thead');

--- a/packages/components/src/components/Table/TableBody/TableBody.tsx
+++ b/packages/components/src/components/Table/TableBody/TableBody.tsx
@@ -2,7 +2,7 @@ import { propagateTestid } from '@/helpers/utility/propagateTestid';
 import { TableEmpty } from '../components/TableEmpty';
 import { TableHeader } from '../components/TableHeader';
 import { useIdIfNeeded } from '@/hooks';
-import { useEffect, useRef, useState, type ReactNode, useContext } from 'react';
+import { useEffect, useState, type ReactNode, useContext } from 'react';
 import { TableRows } from '../components/TableRows';
 import {
   type AriaRelationshipProps,
@@ -10,7 +10,6 @@ import {
 } from '@/hooks/useAriaRelationship';
 import { table } from '../Table.styles';
 import type { IressTableProps } from '../Table';
-import type { TableVirtualiseOptions } from '../Table';
 import { TableContext, TableProvider } from '../TableProvider';
 import { IressExpanderChevron } from '../../ExpanderChevron';
 import { styled } from '@/styled-system/jsx';
@@ -50,11 +49,6 @@ export interface IressTableBodyProps<
    * When true, all rows will be visible, otherwise they are hidden.
    */
   open?: boolean;
-
-  /**
-   * Enable row virtualisation for large datasets.
-   */
-  virtualise?: boolean | TableVirtualiseOptions;
 }
 
 interface TableBodyHeaderProps
@@ -142,7 +136,6 @@ export const IressTableBody = <TRow extends object = never, TVal = never>({
   rowProps,
   rows = [],
   scope,
-  virtualise,
   ...restProps
 }: IressTableBodyProps<TRow, TVal>) => {
   const [isOpen, setIsOpen] = useState(open);
@@ -150,16 +143,6 @@ export const IressTableBody = <TRow extends object = never, TVal = never>({
     useAriaRelationship<HTMLTableCellElement>('aria-controls');
   const id = useIdIfNeeded({ id: restProps.id });
   const showTable = children ?? (empty && columns?.length) ?? !!rows?.length;
-  const tbodyRef = useRef<HTMLTableSectionElement>(null);
-  const scrollContainerRef = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    if (virtualise && tbodyRef.current) {
-      scrollContainerRef.current = tbodyRef.current.closest<HTMLDivElement>(
-        '[class*="table__root"]',
-      );
-    }
-  }, [virtualise]);
 
   useEffect((): void => {
     setIsOpen(open);
@@ -183,11 +166,7 @@ export const IressTableBody = <TRow extends object = never, TVal = never>({
 
   return (
     <TableProvider columns={columns} rows={rows}>
-      <styled.tbody
-        ref={tbodyRef}
-        aria-labelledby={`${id}--caption`}
-        {...restProps}
-      >
+      <styled.tbody aria-labelledby={`${id}--caption`} {...restProps}>
         <TableBodyHeader
           setController={setController}
           caption={caption}
@@ -214,8 +193,6 @@ export const IressTableBody = <TRow extends object = never, TVal = never>({
               scope={scope}
               hiddenHeader={hiddenHeader}
               testId={propagateTestid(dataTestId, 'tbody')}
-              virtualise={virtualise}
-              scrollContainerRef={scrollContainerRef}
             />
             <TableEmpty>{empty}</TableEmpty>
             <TableBodyChildren setControlViaRef={setControlViaRef} tableId={id}>

--- a/packages/components/src/components/Table/TableBody/TableBody.tsx
+++ b/packages/components/src/components/Table/TableBody/TableBody.tsx
@@ -2,7 +2,7 @@ import { propagateTestid } from '@/helpers/utility/propagateTestid';
 import { TableEmpty } from '../components/TableEmpty';
 import { TableHeader } from '../components/TableHeader';
 import { useIdIfNeeded } from '@/hooks';
-import { useEffect, useState, type ReactNode, useContext } from 'react';
+import { useEffect, useRef, useState, type ReactNode, useContext } from 'react';
 import { TableRows } from '../components/TableRows';
 import {
   type AriaRelationshipProps,
@@ -10,6 +10,7 @@ import {
 } from '@/hooks/useAriaRelationship';
 import { table } from '../Table.styles';
 import { type IressTableProps } from '../Table';
+import { type TableVirtualiseOptions } from '../Table';
 import { TableContext, TableProvider } from '../TableProvider';
 import { IressExpanderChevron } from '../../ExpanderChevron';
 import { styled } from '@/styled-system/jsx';
@@ -49,6 +50,11 @@ export interface IressTableBodyProps<
    * When true, all rows will be visible, otherwise they are hidden.
    */
   open?: boolean;
+
+  /**
+   * Enable row virtualisation for large datasets.
+   */
+  virtualise?: boolean | TableVirtualiseOptions;
 }
 
 interface TableBodyHeaderProps
@@ -136,6 +142,7 @@ export const IressTableBody = <TRow extends object = never, TVal = never>({
   rowProps,
   rows = [],
   scope,
+  virtualise,
   ...restProps
 }: IressTableBodyProps<TRow, TVal>) => {
   const [isOpen, setIsOpen] = useState(open);
@@ -143,6 +150,7 @@ export const IressTableBody = <TRow extends object = never, TVal = never>({
     useAriaRelationship<HTMLTableCellElement>('aria-controls');
   const id = useIdIfNeeded({ id: restProps.id });
   const showTable = children ?? (empty && columns?.length) ?? !!rows?.length;
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
 
   useEffect((): void => {
     setIsOpen(open);
@@ -193,6 +201,8 @@ export const IressTableBody = <TRow extends object = never, TVal = never>({
               scope={scope}
               hiddenHeader={hiddenHeader}
               testId={propagateTestid(dataTestId, 'tbody')}
+              virtualise={virtualise}
+              scrollContainerRef={scrollContainerRef}
             />
             <TableEmpty>{empty}</TableEmpty>
             <TableBodyChildren setControlViaRef={setControlViaRef} tableId={id}>

--- a/packages/components/src/components/Table/TableBody/TableBody.tsx
+++ b/packages/components/src/components/Table/TableBody/TableBody.tsx
@@ -9,8 +9,8 @@ import {
   useAriaRelationship,
 } from '@/hooks/useAriaRelationship';
 import { table } from '../Table.styles';
-import { type IressTableProps } from '../Table';
-import { type TableVirtualiseOptions } from '../Table';
+import type { IressTableProps } from '../Table';
+import type { TableVirtualiseOptions } from '../Table';
 import { TableContext, TableProvider } from '../TableProvider';
 import { IressExpanderChevron } from '../../ExpanderChevron';
 import { styled } from '@/styled-system/jsx';

--- a/packages/components/src/components/Table/TableBody/TableBody.tsx
+++ b/packages/components/src/components/Table/TableBody/TableBody.tsx
@@ -150,7 +150,16 @@ export const IressTableBody = <TRow extends object = never, TVal = never>({
     useAriaRelationship<HTMLTableCellElement>('aria-controls');
   const id = useIdIfNeeded({ id: restProps.id });
   const showTable = children ?? (empty && columns?.length) ?? !!rows?.length;
-  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const tbodyRef = useRef<HTMLTableSectionElement>(null);
+  const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (virtualise && tbodyRef.current) {
+      scrollContainerRef.current = tbodyRef.current.closest<HTMLDivElement>(
+        '[class*="table__root"]',
+      );
+    }
+  }, [virtualise]);
 
   useEffect((): void => {
     setIsOpen(open);
@@ -174,7 +183,11 @@ export const IressTableBody = <TRow extends object = never, TVal = never>({
 
   return (
     <TableProvider columns={columns} rows={rows}>
-      <styled.tbody aria-labelledby={`${id}--caption`} {...restProps}>
+      <styled.tbody
+        ref={tbodyRef}
+        aria-labelledby={`${id}--caption`}
+        {...restProps}
+      >
         <TableBodyHeader
           setController={setController}
           caption={caption}

--- a/packages/components/src/components/Table/components/TableRows.tsx
+++ b/packages/components/src/components/Table/components/TableRows.tsx
@@ -24,6 +24,97 @@ export interface TableRowsProps<TRow extends object = never> extends Partial<
   scrollContainerRef?: RefObject<HTMLDivElement | null>;
 }
 
+const VirtualTableRows = <TRow extends object = never>({
+  additionalHeaders,
+  hiddenHeader,
+  rowProps = {},
+  setControlViaRef,
+  scope = 'row',
+  tableId,
+  testId,
+  virtualise,
+  scrollContainerRef,
+  rows,
+}: TableRowsProps<TRow> & { rows: Row<TRow>[] }) => {
+  const virtualiseOptions =
+    typeof virtualise === 'object' ? virtualise : undefined;
+
+  // eslint-disable-next-line react-hooks/incompatible-library -- TanStack Virtual's API is intentionally non-memoizable
+  const virtualizer = useVirtualizer({
+    count: rows.length,
+    getScrollElement: () => scrollContainerRef?.current ?? null,
+    estimateSize: () => virtualiseOptions?.estimateSize ?? 40,
+    overscan: virtualiseOptions?.overscan ?? 5,
+    getItemKey: (index) => rows[index]?.id ?? index,
+    ...(virtualiseOptions?.initialRect && {
+      initialRect: virtualiseOptions.initialRect,
+    }),
+  });
+
+  const virtualItems = virtualizer.getVirtualItems();
+
+  if (!virtualItems.length) return null;
+
+  const paddingTop = virtualItems[0].start;
+  const paddingBottom =
+    virtualizer.getTotalSize() - virtualItems[virtualItems.length - 1].end;
+  const colSpan = rows[0].getVisibleCells().length;
+
+  return (
+    <>
+      {paddingTop > 0 && (
+        <tr aria-hidden="true">
+          <td colSpan={colSpan} style={{ height: paddingTop }} />
+        </tr>
+      )}
+      {virtualItems.map((virtualRow) => {
+        const row = rows[virtualRow.index];
+        return (
+          <styled.tr
+            key={row.id}
+            data-testid={testId?.replace('tbody', 'row')}
+            id={`${tableId}--rows--${row.id}`}
+            aria-rowindex={virtualRow.index + 2}
+            onFocus={() => {
+              virtualizer.scrollToIndex(virtualRow.index, {
+                align: 'auto',
+              });
+            }}
+            ref={(element) => {
+              const rowId = `${tableId}--rows--${row.id}`;
+              setControlViaRef?.(rowId)(element);
+            }}
+            {...(typeof rowProps === 'function' ? rowProps(row) : rowProps)}
+          >
+            {row.getVisibleCells().map((cell, index) => (
+              <TableBodyCell
+                additionalHeaders={additionalHeaders}
+                data-testid={propagateTestid(
+                  testId?.replace('tbody', 'cell'),
+                  `row_${row.id}__col_${cell.column.id}`,
+                )}
+                key={cell.id}
+                cellApi={cell}
+                hiddenHeader={hiddenHeader}
+                index={index}
+                scope={scope}
+                tableId={tableId}
+              >
+                {flexRender(cell.column.columnDef.cell, cell.getContext())}
+              </TableBodyCell>
+            ))}
+          </styled.tr>
+        );
+      })}
+      {paddingBottom > 0 && (
+        <tr aria-hidden="true">
+          <td colSpan={colSpan} style={{ height: paddingBottom }} />
+        </tr>
+      )}
+    </>
+  );
+};
+
 export const TableRows = <TRow extends object = never>({
   additionalHeaders,
   hiddenHeader,
@@ -38,86 +129,22 @@ export const TableRows = <TRow extends object = never>({
   const table = useContext(getTableContext<TRow>());
   const rows = table?.api.getSortedRowModel().rows;
 
-  const virtualiseOptions =
-    typeof virtualise === 'object' ? virtualise : undefined;
-
-  // eslint-disable-next-line react-hooks/incompatible-library -- TanStack Virtual's API is intentionally non-memoizable
-  const virtualizer = useVirtualizer({
-    count: rows?.length ?? 0,
-    getScrollElement: () => scrollContainerRef?.current ?? null,
-    estimateSize: () => virtualiseOptions?.estimateSize ?? 40,
-    overscan: virtualiseOptions?.overscan ?? 5,
-    enabled: !!virtualise,
-    getItemKey: (index) => rows?.[index]?.id ?? index,
-    ...(virtualiseOptions?.initialRect && {
-      initialRect: virtualiseOptions.initialRect,
-    }),
-  });
-
   if (!rows?.length) return null;
 
   if (virtualise) {
-    const virtualItems = virtualizer.getVirtualItems();
-
-    if (!virtualItems.length) return null;
-
-    const paddingTop = virtualItems[0].start;
-    const paddingBottom =
-      virtualizer.getTotalSize() - virtualItems[virtualItems.length - 1].end;
-    const colSpan = rows[0].getVisibleCells().length;
-
     return (
-      <>
-        {paddingTop > 0 && (
-          <tr aria-hidden="true">
-            <td colSpan={colSpan} style={{ height: paddingTop }} />
-          </tr>
-        )}
-        {virtualItems.map((virtualRow) => {
-          const row = rows[virtualRow.index];
-          return (
-            <styled.tr
-              key={row.id}
-              data-testid={testId?.replace('tbody', 'row')}
-              id={`${tableId}--rows--${row.id}`}
-              aria-rowindex={virtualRow.index + 1}
-              onFocus={() => {
-                virtualizer.scrollToIndex(virtualRow.index, {
-                  align: 'auto',
-                });
-              }}
-              ref={(element) => {
-                const rowId = `${tableId}--rows--${row.id}`;
-                setControlViaRef?.(rowId)(element);
-              }}
-              {...(typeof rowProps === 'function' ? rowProps(row) : rowProps)}
-            >
-              {row.getVisibleCells().map((cell, index) => (
-                <TableBodyCell
-                  additionalHeaders={additionalHeaders}
-                  data-testid={propagateTestid(
-                    testId?.replace('tbody', 'cell'),
-                    `row_${row.id}__col_${cell.column.id}`,
-                  )}
-                  key={cell.id}
-                  cellApi={cell}
-                  hiddenHeader={hiddenHeader}
-                  index={index}
-                  scope={scope}
-                  tableId={tableId}
-                >
-                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                </TableBodyCell>
-              ))}
-            </styled.tr>
-          );
-        })}
-        {paddingBottom > 0 && (
-          <tr aria-hidden="true">
-            <td colSpan={colSpan} style={{ height: paddingBottom }} />
-          </tr>
-        )}
-      </>
+      <VirtualTableRows
+        additionalHeaders={additionalHeaders}
+        hiddenHeader={hiddenHeader}
+        rowProps={rowProps}
+        setControlViaRef={setControlViaRef}
+        scope={scope}
+        tableId={tableId}
+        testId={testId}
+        virtualise={virtualise}
+        scrollContainerRef={scrollContainerRef}
+        rows={rows}
+      />
     );
   }
 

--- a/packages/components/src/components/Table/components/TableRows.tsx
+++ b/packages/components/src/components/Table/components/TableRows.tsx
@@ -2,12 +2,12 @@ import { flexRender, type Row } from '@tanstack/react-table';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { TableBodyCell } from './TableBodyCell';
 import { propagateTestid } from '@helpers/utility/propagateTestid';
-import { type IressStyledProps } from '@/types';
-import { type AriaRelationshipProps } from '@/hooks/useAriaRelationship';
+import type { IressStyledProps } from '@/types';
+import type { AriaRelationshipProps } from '@/hooks/useAriaRelationship';
 import { type RefObject, useContext } from 'react';
 import { getTableContext } from '../TableProvider';
 import { styled } from '@/styled-system/jsx';
-import { type TableVirtualiseOptions } from '../Table';
+import type { TableVirtualiseOptions } from '../Table';
 
 export interface TableRowsProps<TRow extends object = never> extends Partial<
   Pick<AriaRelationshipProps, 'setControlViaRef'>

--- a/packages/components/src/components/Table/components/TableRows.tsx
+++ b/packages/components/src/components/Table/components/TableRows.tsx
@@ -64,12 +64,13 @@ export const TableRows = <TRow extends object = never>({
     const paddingTop = virtualItems[0].start;
     const paddingBottom =
       virtualizer.getTotalSize() - virtualItems[virtualItems.length - 1].end;
+    const colSpan = rows[0].getVisibleCells().length;
 
     return (
       <>
         {paddingTop > 0 && (
-          <tr>
-            <td style={{ height: paddingTop, padding: 0, border: 'none' }} />
+          <tr aria-hidden="true">
+            <td colSpan={colSpan} style={{ height: paddingTop }} />
           </tr>
         )}
         {virtualItems.map((virtualRow) => {
@@ -112,8 +113,8 @@ export const TableRows = <TRow extends object = never>({
           );
         })}
         {paddingBottom > 0 && (
-          <tr>
-            <td style={{ height: paddingBottom, padding: 0, border: 'none' }} />
+          <tr aria-hidden="true">
+            <td colSpan={colSpan} style={{ height: paddingBottom }} />
           </tr>
         )}
       </>

--- a/packages/components/src/components/Table/components/TableRows.tsx
+++ b/packages/components/src/components/Table/components/TableRows.tsx
@@ -1,11 +1,13 @@
 import { flexRender, type Row } from '@tanstack/react-table';
+import { useVirtualizer } from '@tanstack/react-virtual';
 import { TableBodyCell } from './TableBodyCell';
 import { propagateTestid } from '@helpers/utility/propagateTestid';
 import { type IressStyledProps } from '@/types';
 import { type AriaRelationshipProps } from '@/hooks/useAriaRelationship';
-import { useContext } from 'react';
+import { type RefObject, useContext } from 'react';
 import { getTableContext } from '../TableProvider';
 import { styled } from '@/styled-system/jsx';
+import { type TableVirtualiseOptions } from '../Table';
 
 export interface TableRowsProps<TRow extends object = never> extends Partial<
   Pick<AriaRelationshipProps, 'setControlViaRef'>
@@ -18,6 +20,8 @@ export interface TableRowsProps<TRow extends object = never> extends Partial<
     | ((row: Row<TRow>) => IressStyledProps<'tr'>);
   tableId: string;
   testId?: string;
+  virtualise?: boolean | TableVirtualiseOptions;
+  scrollContainerRef?: RefObject<HTMLDivElement | null>;
 }
 
 export const TableRows = <TRow extends object = never>({
@@ -28,11 +32,93 @@ export const TableRows = <TRow extends object = never>({
   scope = 'row',
   tableId,
   testId,
+  virtualise,
+  scrollContainerRef,
 }: TableRowsProps<TRow>) => {
   const table = useContext(getTableContext<TRow>());
   const rows = table?.api.getSortedRowModel().rows;
 
+  const virtualiseOptions =
+    typeof virtualise === 'object' ? virtualise : undefined;
+
+  // eslint-disable-next-line react-hooks/incompatible-library -- TanStack Virtual's API is intentionally non-memoizable
+  const virtualizer = useVirtualizer({
+    count: rows?.length ?? 0,
+    getScrollElement: () => scrollContainerRef?.current ?? null,
+    estimateSize: () => virtualiseOptions?.estimateSize ?? 40,
+    overscan: virtualiseOptions?.overscan ?? 5,
+    enabled: !!virtualise,
+    getItemKey: (index) => rows?.[index]?.id ?? index,
+    ...(virtualiseOptions?.initialRect && {
+      initialRect: virtualiseOptions.initialRect,
+    }),
+  });
+
   if (!rows?.length) return null;
+
+  if (virtualise) {
+    const virtualItems = virtualizer.getVirtualItems();
+
+    if (!virtualItems.length) return null;
+
+    const paddingTop = virtualItems[0].start;
+    const paddingBottom =
+      virtualizer.getTotalSize() - virtualItems[virtualItems.length - 1].end;
+
+    return (
+      <>
+        {paddingTop > 0 && (
+          <tr>
+            <td style={{ height: paddingTop, padding: 0, border: 'none' }} />
+          </tr>
+        )}
+        {virtualItems.map((virtualRow) => {
+          const row = rows[virtualRow.index];
+          return (
+            <styled.tr
+              key={row.id}
+              data-testid={testId?.replace('tbody', 'row')}
+              id={`${tableId}--rows--${row.id}`}
+              aria-rowindex={virtualRow.index + 1}
+              onFocus={() => {
+                virtualizer.scrollToIndex(virtualRow.index, {
+                  align: 'auto',
+                });
+              }}
+              ref={(element) => {
+                const rowId = `${tableId}--rows--${row.id}`;
+                setControlViaRef?.(rowId)(element);
+              }}
+              {...(typeof rowProps === 'function' ? rowProps(row) : rowProps)}
+            >
+              {row.getVisibleCells().map((cell, index) => (
+                <TableBodyCell
+                  additionalHeaders={additionalHeaders}
+                  data-testid={propagateTestid(
+                    testId?.replace('tbody', 'cell'),
+                    `row_${row.id}__col_${cell.column.id}`,
+                  )}
+                  key={cell.id}
+                  cellApi={cell}
+                  hiddenHeader={hiddenHeader}
+                  index={index}
+                  scope={scope}
+                  tableId={tableId}
+                >
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </TableBodyCell>
+              ))}
+            </styled.tr>
+          );
+        })}
+        {paddingBottom > 0 && (
+          <tr>
+            <td style={{ height: paddingBottom, padding: 0, border: 'none' }} />
+          </tr>
+        )}
+      </>
+    );
+  }
 
   return rows.map((row) => (
     <styled.tr

--- a/packages/components/src/components/Table/mocks/TableVirtualised.tsx
+++ b/packages/components/src/components/Table/mocks/TableVirtualised.tsx
@@ -1,0 +1,95 @@
+import { useState } from 'react';
+import {
+  IressButton,
+  IressInline,
+  IressPill,
+  IressStack,
+  IressTable,
+  IressText,
+  IressToggle,
+  type TableColumn,
+} from '@/main';
+
+interface Row {
+  id: string;
+  name: string;
+  value: string;
+  status: 'pending' | 'approved' | 'rejected';
+}
+
+const ROW_COUNT = 1000;
+
+const generateRows = (count: number): Row[] =>
+  Array.from({ length: count }, (_, i) => ({
+    id: `${i}`,
+    name: `Item ${i}`,
+    value: `Value ${i}`,
+    status: 'pending' as const,
+  }));
+
+const columns: TableColumn<Row, string>[] = [
+  { key: 'name', label: 'Name', width: '35%' },
+  { key: 'value', label: 'Value', width: '35%' },
+  {
+    key: 'status',
+    label: 'Status',
+    width: '30%',
+    format: (value: string) => {
+      const modeMap = {
+        approved: 'success',
+        rejected: 'danger',
+      } as const;
+      const mode = modeMap[value as keyof typeof modeMap] ?? 'info';
+      return <IressPill mode={mode}>{value}</IressPill>;
+    },
+  },
+];
+
+export const TableVirtualised = () => {
+  const [rows, setRows] = useState(() => generateRows(ROW_COUNT));
+  const [virtualised, setVirtualised] = useState(true);
+  const [lastDuration, setLastDuration] = useState<number | null>(null);
+
+  const updateAll = (status: Row['status']) => {
+    const start = performance.now();
+    setRows((prev) => prev.map((r) => ({ ...r, status })));
+    requestAnimationFrame(() => {
+      setLastDuration(Math.round(performance.now() - start));
+    });
+  };
+
+  return (
+    <IressStack gap="md">
+      <IressInline gap="sm" verticalAlign="middle">
+        <IressToggle
+          checked={virtualised}
+          onChange={() => setVirtualised((v) => !v)}
+        >
+          Virtualisation {virtualised ? 'on' : 'off'}
+        </IressToggle>
+        <IressButton mode="primary" onClick={() => updateAll('approved')}>
+          Approve All
+        </IressButton>
+        <IressButton mode="secondary" onClick={() => updateAll('rejected')}>
+          Reject All
+        </IressButton>
+        <IressButton mode="tertiary" onClick={() => updateAll('pending')}>
+          Reset
+        </IressButton>
+        {lastDuration !== null && (
+          <IressText>Last update: {lastDuration}ms</IressText>
+        )}
+      </IressInline>
+      <IressText>
+        {ROW_COUNT} rows — toggle virtualisation off to feel the difference.
+      </IressText>
+      <IressTable
+        caption="Virtualisation demo"
+        rows={rows}
+        columns={columns}
+        virtualise={virtualised ? { height: 500 } : undefined}
+        compact
+      />
+    </IressStack>
+  );
+};

--- a/packages/components/src/patterns/Form/mocks/FormGroups.tsx
+++ b/packages/components/src/patterns/Form/mocks/FormGroups.tsx
@@ -65,7 +65,11 @@ const defaultValues = {
 
 const ClientSection: React.FC<ClientProps> = ({ control }) => {
   return (
-    <IressFieldGroup label={<IressText element="h2">Client</IressText>} inline>
+    <IressFieldGroup
+      label={<IressText element="h2">Client</IressText>}
+      inline
+      mb="none"
+    >
       <IressFormField
         name="client.name"
         label="Name"
@@ -111,6 +115,7 @@ const DependantSection: React.FC<DependantProps> = ({
         <IressFieldGroup
           label={<IressText element="h2">Dependant {index + 1}</IressText>}
           inline
+          mb="none"
         >
           <IressFormField
             name={`dependants.${index}.name`}

--- a/packages/storybook-config/package.json
+++ b/packages/storybook-config/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^5.1.1",
-    "@iress-oss/ids-components": "^6.0.0-beta.3",
+    "@iress-oss/ids-components": "^6.0.0-beta.7",
     "@iress-oss/ids-storybook-okta": "^0.1.2",
     "@iress-oss/ids-storybook-sandbox": "^0.2.2",
     "@iress-oss/ids-storybook-toggle-stories": "^0.1.0",

--- a/packages/theme-preset/package.json
+++ b/packages/theme-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iress-oss/ids-theme-preset",
-  "version": "6.0.0-beta.2",
+  "version": "6.0.0-beta.3",
   "description": "Panda CSS preset for the Iress Design System",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/theme-preset/src/config-recipes/table.ts
+++ b/packages/theme-preset/src/config-recipes/table.ts
@@ -200,6 +200,34 @@ export const tableRecipe = defineSlotRecipe({
         },
       },
     },
+    virtualise: {
+      true: {
+        table: {
+          tableLayout: 'fixed',
+
+          '& thead': {
+            position: 'sticky',
+            top: 0,
+            zIndex: 1,
+            bg: 'colour.neutral.10',
+          },
+        },
+        root: {
+          '&[data-scrolled] table > thead:first-of-type > :first-child > :first-child':
+            {
+              borderTopLeftRadius: '0',
+            },
+          '&[data-scrolled] table > thead:first-of-type > :first-child > :last-child':
+            {
+              borderTopRightRadius: '0',
+            },
+          '&[data-scrolled] table > thead:first-of-type > :first-child > th, &[data-scrolled] table > thead:first-of-type > :first-child > td':
+            {
+              borderTopWidth: '1px',
+            },
+        },
+      },
+    },
     sortButtonNoWrap: {
       true: {
         sortHeader: {

--- a/packages/theme-preset/src/config-recipes/table.ts
+++ b/packages/theme-preset/src/config-recipes/table.ts
@@ -211,6 +211,11 @@ export const tableRecipe = defineSlotRecipe({
             zIndex: 1,
             bg: 'colour.neutral.10',
           },
+
+          '& tr[aria-hidden] td': {
+            padding: '0',
+            border: 'none',
+          },
         },
         root: {
           '&[data-scrolled] table > thead:first-of-type > :first-child > :first-child':

--- a/yarn.lock
+++ b/yarn.lock
@@ -1334,13 +1334,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@iress-oss/ids-components@npm:^6.0.0-beta.3, @iress-oss/ids-components@workspace:packages/components":
+"@iress-oss/ids-components@npm:^6.0.0-beta.7, @iress-oss/ids-components@workspace:packages/components":
   version: 0.0.0-use.local
   resolution: "@iress-oss/ids-components@workspace:packages/components"
   dependencies:
     "@floating-ui/react": "npm:0.27.19"
     "@fortawesome/fontawesome-common-types": "npm:0.2.36"
-    "@iress-oss/ids-theme-preset": "npm:^6.0.0-beta.2"
+    "@iress-oss/ids-theme-preset": "npm:^6.0.0-beta.3"
     "@iress-oss/ids-tokens": "npm:^6.0.0-beta.2"
     "@pandacss/dev": "npm:1.9.1"
     "@tanstack/react-table": "npm:8.21.3"
@@ -1408,7 +1408,7 @@ __metadata:
   resolution: "@iress-oss/ids-storybook-config@workspace:packages/storybook-config"
   dependencies:
     "@chromatic-com/storybook": "npm:^5.1.1"
-    "@iress-oss/ids-components": "npm:^6.0.0-beta.3"
+    "@iress-oss/ids-components": "npm:^6.0.0-beta.7"
     "@iress-oss/ids-storybook-okta": "npm:^0.1.2"
     "@iress-oss/ids-storybook-sandbox": "npm:^0.2.2"
     "@iress-oss/ids-storybook-toggle-stories": "npm:^0.1.0"
@@ -1626,7 +1626,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@iress-oss/ids-theme-preset@npm:^6.0.0-beta.2, @iress-oss/ids-theme-preset@workspace:packages/theme-preset":
+"@iress-oss/ids-theme-preset@npm:^6.0.0-beta.3, @iress-oss/ids-theme-preset@workspace:packages/theme-preset":
   version: 0.0.0-use.local
   resolution: "@iress-oss/ids-theme-preset@workspace:packages/theme-preset"
   dependencies:
@@ -1703,7 +1703,7 @@ __metadata:
   resolution: "@iress/design-system-monorepo@workspace:."
   dependencies:
     "@chromatic-com/storybook": "npm:^5.1.1"
-    "@iress-oss/ids-components": "npm:^6.0.0-beta.3"
+    "@iress-oss/ids-components": "npm:^6.0.0-beta.7"
     "@iress-oss/ids-storybook-config": "npm:^0.6.0"
     "@iress-oss/ids-storybook-okta": "npm:^0.1.2"
     "@iress-oss/ids-storybook-sandbox": "npm:^0.2.2"
@@ -3856,12 +3856,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:>=20.0.0":
-  version: 25.5.0
-  resolution: "@types/node@npm:25.5.0"
+"@types/node@npm:*, @types/node@npm:>=20.0.0, @types/node@npm:^25.6.0":
+  version: 25.6.0
+  resolution: "@types/node@npm:25.6.0"
   dependencies:
-    undici-types: "npm:~7.18.0"
-  checksum: 10c0/70c508165b6758c4f88d4f91abca526c3985eee1985503d4c2bd994dbaf588e52ac57e571160f18f117d76e963570ac82bd20e743c18987e82564312b3b62119
+    undici-types: "npm:~7.19.0"
+  checksum: 10c0/d2d2015630ff098a201407f55f5077a20270ae4f465c739b40865cd9933b91b9c5d2b85568eadaf3db0801b91e267333ca7eb39f007428b173d1cdab4b339ac5
   languageName: node
   linkType: hard
 
@@ -3887,15 +3887,6 @@ __metadata:
   dependencies:
     undici-types: "npm:~7.16.0"
   checksum: 10c0/d6bca7a78f550fbb376f236f92b405d676003a8a09a1b411f55920ef34286ee3ee51f566203920e835478784df52662b5b2af89159d9d319352e9ea21801c002
-  languageName: node
-  linkType: hard
-
-"@types/node@npm:^25.6.0":
-  version: 25.6.0
-  resolution: "@types/node@npm:25.6.0"
-  dependencies:
-    undici-types: "npm:~7.19.0"
-  checksum: 10c0/d2d2015630ff098a201407f55f5077a20270ae4f465c739b40865cd9933b91b9c5d2b85568eadaf3db0801b91e267333ca7eb39f007428b173d1cdab4b339ac5
   languageName: node
   linkType: hard
 
@@ -6541,19 +6532,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:*, dompurify@npm:^3.2.5":
-  version: 3.3.3
-  resolution: "dompurify@npm:3.3.3"
-  dependencies:
-    "@types/trusted-types": "npm:^2.0.7"
-  dependenciesMeta:
-    "@types/trusted-types":
-      optional: true
-  checksum: 10c0/097c14a21a3f6cb95beded9ecd255f7c3512c42767b048390c747b0fe35736f6a71e02320fc50a9ac2be645834b463e4760915d595d502a56452daf339d0ea9c
-  languageName: node
-  linkType: hard
-
-"dompurify@npm:^3.4.1":
+"dompurify@npm:*, dompurify@npm:^3.2.5, dompurify@npm:^3.4.1":
   version: 3.4.1
   resolution: "dompurify@npm:3.4.1"
   dependencies:
@@ -11151,7 +11130,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:4.0.3, picomatch@npm:^4.0.0, picomatch@npm:^4.0.2, picomatch@npm:^4.0.3":
+"picomatch@npm:4.0.3":
   version: 4.0.3
   resolution: "picomatch@npm:4.0.3"
   checksum: 10c0/9582c951e95eebee5434f59e426cddd228a7b97a0161a375aed4be244bd3fe8e3a31b846808ea14ef2c8a2527a6eeab7b3946a67d5979e81694654f939473ae2
@@ -11165,7 +11144,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^4.0.4":
+"picomatch@npm:^4.0.0, picomatch@npm:^4.0.2, picomatch@npm:^4.0.3, picomatch@npm:^4.0.4":
   version: 4.0.4
   resolution: "picomatch@npm:4.0.4"
   checksum: 10c0/e2c6023372cc7b5764719a5ffb9da0f8e781212fa7ca4bd0562db929df8e117460f00dff3cb7509dacfc06b86de924b247f504d0ce1806a37fac4633081466b0
@@ -11441,7 +11420,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:8.5.9":
+"postcss@npm:8.5.9, postcss@npm:^8.4.47, postcss@npm:^8.5.6, postcss@npm:^8.5.8":
   version: 8.5.9
   resolution: "postcss@npm:8.5.9"
   dependencies:
@@ -11449,17 +11428,6 @@ __metadata:
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
   checksum: 10c0/7cb2b32202ea1ead03f15cfbb2756a64a0f98942378e99b3dfce33678fe5eaf93e31d675a46e3a0dfb417d7b49b82d8999d0dd42a33c3b128e71ade0f978719a
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^8.4.47, postcss@npm:^8.5.6, postcss@npm:^8.5.8":
-  version: 8.5.8
-  resolution: "postcss@npm:8.5.8"
-  dependencies:
-    nanoid: "npm:^3.3.11"
-    picocolors: "npm:^1.1.1"
-    source-map-js: "npm:^1.2.1"
-  checksum: 10c0/dd918f7127ee7c60a0295bae2e72b3787892296e1d1c3c564d7a2a00c68d8df83cadc3178491259daa19ccc54804fb71ed8c937c6787e08d8bd4bedf8d17044c
   languageName: node
   linkType: hard
 
@@ -11488,16 +11456,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^3.3.3":
-  version: 3.8.1
-  resolution: "prettier@npm:3.8.1"
-  bin:
-    prettier: bin/prettier.cjs
-  checksum: 10c0/33169b594009e48f570471271be7eac7cdcf88a209eed39ac3b8d6d78984039bfa9132f82b7e6ba3b06711f3bfe0222a62a1bfb87c43f50c25a83df1b78a2c42
-  languageName: node
-  linkType: hard
-
-"prettier@npm:^3.8.2":
+"prettier@npm:^3.3.3, prettier@npm:^3.8.2":
   version: 3.8.3
   resolution: "prettier@npm:3.8.3"
   bin:
@@ -13474,16 +13433,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-api-utils@npm:^2.4.0":
-  version: 2.4.0
-  resolution: "ts-api-utils@npm:2.4.0"
-  peerDependencies:
-    typescript: ">=4.8.4"
-  checksum: 10c0/ed185861aef4e7124366a3f6561113557a57504267d4d452a51e0ba516a9b6e713b56b4aeaab9fa13de9db9ab755c65c8c13a777dba9133c214632cb7b65c083
-  languageName: node
-  linkType: hard
-
-"ts-api-utils@npm:^2.5.0":
+"ts-api-utils@npm:^2.4.0, ts-api-utils@npm:^2.5.0":
   version: 2.5.0
   resolution: "ts-api-utils@npm:2.5.0"
   peerDependencies:
@@ -13743,13 +13693,6 @@ __metadata:
   version: 7.16.0
   resolution: "undici-types@npm:7.16.0"
   checksum: 10c0/3033e2f2b5c9f1504bdc5934646cb54e37ecaca0f9249c983f7b1fc2e87c6d18399ebb05dc7fd5419e02b2e915f734d872a65da2e3eeed1813951c427d33cc9a
-  languageName: node
-  linkType: hard
-
-"undici-types@npm:~7.18.0":
-  version: 7.18.2
-  resolution: "undici-types@npm:7.18.2"
-  checksum: 10c0/85a79189113a238959d7a647368e4f7c5559c3a404ebdb8fc4488145ce9426fcd82252a844a302798dfc0e37e6fb178ff481ed03bc4caf634c5757d9ef43521d
   languageName: node
   linkType: hard
 
@@ -14533,22 +14476,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^8.18.0, ws@npm:^8.18.3, ws@npm:^8.19.0":
-  version: 8.19.0
-  resolution: "ws@npm:8.19.0"
-  peerDependencies:
-    bufferutil: ^4.0.1
-    utf-8-validate: ">=5.0.2"
-  peerDependenciesMeta:
-    bufferutil:
-      optional: true
-    utf-8-validate:
-      optional: true
-  checksum: 10c0/4741d9b9bc3f9c791880882414f96e36b8b254e34d4b503279d6400d9a4b87a033834856dbdd94ee4b637944df17ea8afc4bce0ff4a1560d2166be8855da5b04
-  languageName: node
-  linkType: hard
-
-"ws@npm:^8.20.0":
+"ws@npm:^8.18.0, ws@npm:^8.18.3, ws@npm:^8.19.0, ws@npm:^8.20.0":
   version: 8.20.0
   resolution: "ws@npm:8.20.0"
   peerDependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1344,6 +1344,7 @@ __metadata:
     "@iress-oss/ids-tokens": "npm:^6.0.0-beta.2"
     "@pandacss/dev": "npm:1.9.1"
     "@tanstack/react-table": "npm:8.21.3"
+    "@tanstack/react-virtual": "npm:3.13.2"
     "@testing-library/dom": "npm:10.4.1"
     "@testing-library/jest-dom": "npm:6.9.1"
     "@testing-library/react": "npm:16.3.2"
@@ -3226,6 +3227,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tanstack/react-virtual@npm:3.13.2":
+  version: 3.13.2
+  resolution: "@tanstack/react-virtual@npm:3.13.2"
+  dependencies:
+    "@tanstack/virtual-core": "npm:3.13.2"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10c0/6341e43c8af79b273deb9283631b881065131191959ffc08e9e83c42e772e0c1576a4787252017650798e2e3961fc7854ee7ea0a8b40dab7354c6a2e830f5db6
+  languageName: node
+  linkType: hard
+
 "@tanstack/react-virtual@npm:^3.13.9":
   version: 3.13.12
   resolution: "@tanstack/react-virtual@npm:3.13.12"
@@ -3249,6 +3262,13 @@ __metadata:
   version: 3.13.12
   resolution: "@tanstack/virtual-core@npm:3.13.12"
   checksum: 10c0/483f38761b73db05c181c10181f0781c1051be3350ae5c378e65057e5f1fdd6606e06e17dbaad8a5e36c04b208ea1a1344cacd4eca0dcde60f335cf398e4d698
+  languageName: node
+  linkType: hard
+
+"@tanstack/virtual-core@npm:3.13.2":
+  version: 3.13.2
+  resolution: "@tanstack/virtual-core@npm:3.13.2"
+  checksum: 10c0/6527f4e2db071e03b6a0768b10405d072c2692551148314e36ea673878c78ea50f10849f173b32ec8b8d265bd624ab03cacb770c60719885e1ca02cdccf04927
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1344,7 +1344,7 @@ __metadata:
     "@iress-oss/ids-tokens": "npm:^6.0.0-beta.2"
     "@pandacss/dev": "npm:1.9.1"
     "@tanstack/react-table": "npm:8.21.3"
-    "@tanstack/react-virtual": "npm:3.13.2"
+    "@tanstack/react-virtual": "npm:3.13.12"
     "@testing-library/dom": "npm:10.4.1"
     "@testing-library/jest-dom": "npm:6.9.1"
     "@testing-library/react": "npm:16.3.2"
@@ -3227,19 +3227,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tanstack/react-virtual@npm:3.13.2":
-  version: 3.13.2
-  resolution: "@tanstack/react-virtual@npm:3.13.2"
-  dependencies:
-    "@tanstack/virtual-core": "npm:3.13.2"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: 10c0/6341e43c8af79b273deb9283631b881065131191959ffc08e9e83c42e772e0c1576a4787252017650798e2e3961fc7854ee7ea0a8b40dab7354c6a2e830f5db6
-  languageName: node
-  linkType: hard
-
-"@tanstack/react-virtual@npm:^3.13.9":
+"@tanstack/react-virtual@npm:3.13.12, @tanstack/react-virtual@npm:^3.13.9":
   version: 3.13.12
   resolution: "@tanstack/react-virtual@npm:3.13.12"
   dependencies:
@@ -3262,13 +3250,6 @@ __metadata:
   version: 3.13.12
   resolution: "@tanstack/virtual-core@npm:3.13.12"
   checksum: 10c0/483f38761b73db05c181c10181f0781c1051be3350ae5c378e65057e5f1fdd6606e06e17dbaad8a5e36c04b208ea1a1344cacd4eca0dcde60f335cf398e4d698
-  languageName: node
-  linkType: hard
-
-"@tanstack/virtual-core@npm:3.13.2":
-  version: 3.13.2
-  resolution: "@tanstack/virtual-core@npm:3.13.2"
-  checksum: 10c0/6527f4e2db071e03b6a0768b10405d072c2692551148314e36ea673878c78ea50f10849f173b32ec8b8d265bd624ab03cacb770c60719885e1ca02cdccf04927
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This pull request adds row virtualisation support to the `IressTable` component, enabling efficient rendering of large datasets by only rendering visible rows plus overscan. It introduces a new `virtualise` prop (with options) to the table, updates documentation and stories, and adds comprehensive tests to ensure correct behaviour and accessibility. Several internal changes were made to support this feature, including integration with `@tanstack/react-virtual` and updates to mock/example usage guidelines.

**Table Virtualisation Feature:**

- Added a `virtualise` prop to `IressTable` and `IressTableBody`, allowing users to enable row virtualisation for large tables. The prop accepts either `true` (for default options) or an options object to configure overscan, estimated row height, container height, and initial rect for SSR/testing. (`[[1]](diffhunk://#diff-e86c6c661c0d2b1bedbcfc55e10ab34a787d3640d81dbc3ea8ce874e4ac16057L7-R42)`, `[[2]](diffhunk://#diff-e86c6c661c0d2b1bedbcfc55e10ab34a787d3640d81dbc3ea8ce874e4ac16057R120-R126)`, `[[3]](diffhunk://#diff-e86c6c661c0d2b1bedbcfc55e10ab34a787d3640d81dbc3ea8ce874e4ac16057R145-R212)`, `[[4]](diffhunk://#diff-e86c6c661c0d2b1bedbcfc55e10ab34a787d3640d81dbc3ea8ce874e4ac16057R234-R235)`, `[[5]](diffhunk://#diff-5fc3dab22248ddcf8ab95b7e5c2e467f58f1521fef4acc7addb45ef1c74bb90cL5-R13)`, `[[6]](diffhunk://#diff-5fc3dab22248ddcf8ab95b7e5c2e467f58f1521fef4acc7addb45ef1c74bb90cR53-R57)`, `[[7]](diffhunk://#diff-5fc3dab22248ddcf8ab95b7e5c2e467f58f1521fef4acc7addb45ef1c74bb90cR145-R153)`, `[[8]](diffhunk://#diff-5fc3dab22248ddcf8ab95b7e5c2e467f58f1521fef4acc7addb45ef1c74bb90cR204-R205)`, `[[9]](diffhunk://#diff-2a28538fa8f64d56d06adefb3cab34fc8fa6536940450940966371200cda7841R2-R10)`, `[[10]](diffhunk://#diff-2a28538fa8f64d56d06adefb3cab34fc8fa6536940450940966371200cda7841R23-R24)`, `[[11]](diffhunk://#diff-2a28538fa8f64d56d06adefb3cab34fc8fa6536940450940966371200cda7841R35-R122)`)
- Implemented virtual row rendering in `TableRows` using `@tanstack/react-virtual`, including padding rows for scroll space and correct `aria-rowindex` and `aria-rowcount` attributes for accessibility. (`[packages/components/src/components/Table/components/TableRows.tsxR35-R122](diffhunk://#diff-2a28538fa8f64d56d06adefb3cab34fc8fa6536940450940966371200cda7841R35-R122)`)
- Updated the table container to require and enforce a fixed height when virtualisation is enabled, and to manage scroll state and styling accordingly. (`[packages/components/src/components/Table/Table.tsxR145-R212](diffhunk://#diff-e86c6c661c0d2b1bedbcfc55e10ab34a787d3640d81dbc3ea8ce874e4ac16057R145-R212)`)

**Documentation and Examples:**

- Expanded the table documentation (`Table.docs.mdx`) with a new section explaining virtualisation, its requirements, options, and accessibility notes. Added a new virtualised table example. (`[packages/components/src/components/Table/Table.docs.mdxR262-R289](diffhunk://#diff-2666b647d50df9ec2d852ff5b03b62495c5668fec113e0cc22303a2b00edcd15R262-R289)`)
- Added a new Storybook story and example component for a virtualised table, demonstrating usage and configuration. (`[[1]](diffhunk://#diff-f53dd0c9ed4ea9a355761b38f9ab0e5ab2a2327ad3771b818d0d1dea86545be3R16-R17)`, `[[2]](diffhunk://#diff-f53dd0c9ed4ea9a355761b38f9ab0e5ab2a2327ad3771b818d0d1dea86545be3R403-R413)`)

**Testing:**

- Added comprehensive tests for virtualisation, including checks for correct row rendering, accessibility attributes, sorting/filtering compatibility, and configuration options. (`[packages/components/src/components/Table/Table.test.tsxR288-R400](diffhunk://#diff-6b4b91a26be4ffdc2e452be6f8cfda15332edd5bd921dade361bc2a77bf25429R288-R400)`)

**Dependencies:**

- Added `@tanstack/react-virtual` as a dependency for efficient row virtualisation. (`[packages/components/package.jsonR81](diffhunk://#diff-2c76dc06185f93bec73660e15338433b95eac6707317564c0f778f5b9abe446cR81)`)

**Mock/Example Guidelines:**

- Updated contribution guidelines to require that mock/example components do not use internal `styled` utilities and must import IDS components from the public entrypoint, ensuring consistency in documentation and examples. (`[AGENTS.mdR83-R85](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R83-R85)`)