### PR TITLE
chore: release v6.0.0 for tokens, theme-preset, and components

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^5.1.1",
-    "@iress-oss/ids-components": "^6.0.0-beta.9",
+    "@iress-oss/ids-components": "^6.0.0",
     "@iress-oss/ids-storybook-config": "^0.6.0",
     "@iress-oss/ids-storybook-okta": "^0.1.2",
     "@iress-oss/ids-storybook-sandbox": "^0.2.2",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iress-oss/ids-components",
-  "version": "6.0.0-beta.9",
+  "version": "6.0.0",
   "description": "Iress React Component Library",
   "license": "Apache-2.0",
   "type": "module",
@@ -31,8 +31,8 @@
     "typecheck:node": "tsc --noEmit -p tsconfig.node.json"
   },
   "devDependencies": {
-    "@iress-oss/ids-theme-preset": "^6.0.0-beta.3",
-    "@iress-oss/ids-tokens": "^6.0.0-beta.2",
+    "@iress-oss/ids-theme-preset": "^6.0.0",
+    "@iress-oss/ids-tokens": "^6.0.0",
     "@pandacss/dev": "1.9.1",
     "@testing-library/dom": "10.4.1",
     "@testing-library/jest-dom": "6.9.1",
@@ -104,6 +104,5 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/iress/design-system"
-  },
-  "stableVersion": "6.0.0-alpha.16"
+  }
 }

--- a/packages/storybook-config/package.json
+++ b/packages/storybook-config/package.json
@@ -42,7 +42,7 @@
     "watch": "vite build --watch"
   },
   "dependencies": {
-    "@iress-oss/ids-tokens": "^6.0.0-beta.1",
+    "@iress-oss/ids-tokens": "^6.0.0",
     "radash": "12.1.1",
     "react-diff-viewer": "^3.1.1",
     "react-element-to-jsx-string": "^17.0.1",
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^5.1.1",
-    "@iress-oss/ids-components": "^6.0.0-beta.9",
+    "@iress-oss/ids-components": "^6.0.0",
     "@iress-oss/ids-storybook-okta": "^0.1.2",
     "@iress-oss/ids-storybook-sandbox": "^0.2.2",
     "@iress-oss/ids-storybook-toggle-stories": "^0.1.0",

--- a/packages/theme-preset/package.json
+++ b/packages/theme-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iress-oss/ids-theme-preset",
-  "version": "6.0.0-beta.3",
+  "version": "6.0.0",
   "description": "Panda CSS preset for the Iress Design System",
   "license": "Apache-2.0",
   "type": "module",
@@ -42,7 +42,7 @@
     "typecheck": "tsc --noEmit -p tsconfig.lib.json"
   },
   "dependencies": {
-    "@iress-oss/ids-tokens": "^6.0.0-beta.2"
+    "@iress-oss/ids-tokens": "^6.0.0"
   },
   "peerDependencies": {
     "@pandacss/dev": ">=1.8.0",
@@ -71,6 +71,5 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/iress/design-system"
-  },
-  "stableVersion": "6.0.0-alpha.1"
+  }
 }

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iress-oss/ids-tokens",
-  "version": "6.0.0-beta.2",
+  "version": "6.0.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -85,6 +85,5 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/iress/design-system"
-  },
-  "stableVersion": "6.0.0-alpha.2"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1352,14 +1352,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@iress-oss/ids-components@npm:^6.0.0-beta.9, @iress-oss/ids-components@workspace:packages/components":
+"@iress-oss/ids-components@npm:^6.0.0, @iress-oss/ids-components@workspace:packages/components":
   version: 0.0.0-use.local
   resolution: "@iress-oss/ids-components@workspace:packages/components"
   dependencies:
     "@floating-ui/react": "npm:0.27.19"
     "@fortawesome/fontawesome-common-types": "npm:0.2.36"
-    "@iress-oss/ids-theme-preset": "npm:^6.0.0-beta.3"
-    "@iress-oss/ids-tokens": "npm:^6.0.0-beta.2"
+    "@iress-oss/ids-theme-preset": "npm:^6.0.0"
+    "@iress-oss/ids-tokens": "npm:^6.0.0"
     "@pandacss/dev": "npm:1.9.1"
     "@tanstack/react-table": "npm:8.21.3"
     "@tanstack/react-virtual": "npm:3.13.12"
@@ -1426,12 +1426,12 @@ __metadata:
   resolution: "@iress-oss/ids-storybook-config@workspace:packages/storybook-config"
   dependencies:
     "@chromatic-com/storybook": "npm:^5.1.1"
-    "@iress-oss/ids-components": "npm:^6.0.0-beta.9"
+    "@iress-oss/ids-components": "npm:^6.0.0"
     "@iress-oss/ids-storybook-okta": "npm:^0.1.2"
     "@iress-oss/ids-storybook-sandbox": "npm:^0.2.2"
     "@iress-oss/ids-storybook-toggle-stories": "npm:^0.1.0"
     "@iress-oss/ids-storybook-version-badge": "npm:^0.1.1"
-    "@iress-oss/ids-tokens": "npm:^6.0.0-beta.1"
+    "@iress-oss/ids-tokens": "npm:^6.0.0"
     "@mdx-js/react": "npm:3.1.1"
     "@storybook/addon-a11y": "npm:10.3.6"
     "@storybook/addon-docs": "npm:10.3.6"
@@ -1644,11 +1644,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@iress-oss/ids-theme-preset@npm:^6.0.0-beta.3, @iress-oss/ids-theme-preset@workspace:packages/theme-preset":
+"@iress-oss/ids-theme-preset@npm:^6.0.0, @iress-oss/ids-theme-preset@workspace:packages/theme-preset":
   version: 0.0.0-use.local
   resolution: "@iress-oss/ids-theme-preset@workspace:packages/theme-preset"
   dependencies:
-    "@iress-oss/ids-tokens": "npm:^6.0.0-beta.2"
+    "@iress-oss/ids-tokens": "npm:^6.0.0"
     "@pandacss/dev": "npm:1.9.1"
     "@pandacss/types": "npm:1.9.1"
     "@typescript-eslint/eslint-plugin": "npm:^8.59.2"
@@ -1670,7 +1670,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@iress-oss/ids-tokens@npm:^6.0.0-beta.1, @iress-oss/ids-tokens@npm:^6.0.0-beta.2, @iress-oss/ids-tokens@workspace:packages/tokens":
+"@iress-oss/ids-tokens@npm:^6.0.0, @iress-oss/ids-tokens@workspace:packages/tokens":
   version: 0.0.0-use.local
   resolution: "@iress-oss/ids-tokens@workspace:packages/tokens"
   dependencies:
@@ -1721,7 +1721,7 @@ __metadata:
   resolution: "@iress/design-system-monorepo@workspace:."
   dependencies:
     "@chromatic-com/storybook": "npm:^5.1.1"
-    "@iress-oss/ids-components": "npm:^6.0.0-beta.9"
+    "@iress-oss/ids-components": "npm:^6.0.0"
     "@iress-oss/ids-storybook-config": "npm:^0.6.0"
     "@iress-oss/ids-storybook-okta": "npm:^0.1.2"
     "@iress-oss/ids-storybook-sandbox": "npm:^0.2.2"


### PR DESCRIPTION
## Summary

Bumps core packages from beta to stable 6.0.0 release:

- `@iress-oss/ids-tokens`: 6.0.0-beta.2 → 6.0.0
- `@iress-oss/ids-theme-preset`: 6.0.0-beta.2 → 6.0.0
- `@iress-oss/ids-components`: 6.0.0-beta.9 → 6.0.0