### PR TITLE
chore: add ids components package metadata

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -103,6 +103,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/iress/design-system"
-  }
+    "url": "https://github.com/iress/design-system",
+    "directory": "packages/components"
+  },
+  "bugs": {
+    "url": "https://github.com/iress/design-system/issues"
+  },
+  "homepage": "https://github.com/iress/design-system/tree/main/packages/components#readme"
 }


### PR DESCRIPTION
## Summary
Add package support metadata to `@iress-oss/ids-components`:
- set `repository.directory` to `packages/components`
- add `bugs.url` pointing to the repository issue tracker
- add `homepage` pointing to the package README

This is a manifest-only change. It does not change component/runtime code, dependencies, exports, build output, or package versions.

## Verification
- Parsed `packages/components/package.json` and confirmed `name`, `license`, `repository.directory`, `homepage`, and `bugs.url`
- `npm pack --dry-run --ignore-scripts --json` from `packages/components`
- `git diff --check`