### PR TITLE
fix(deps): resolve shell-quote vulnerability (GHSA-w7jw-789q-3m8p)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
       "packages/*"
     ]
   },
+  "resolutions": {
+    "shell-quote": "1.8.4"
+  },
   "devDependencies": {
     "@chromatic-com/storybook": "^5.1.1",
     "@iress-oss/ids-components": "^6.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12684,10 +12684,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shell-quote@npm:1.8.3":
-  version: 1.8.3
-  resolution: "shell-quote@npm:1.8.3"
-  checksum: 10c0/bee87c34e1e986cfb4c30846b8e6327d18874f10b535699866f368ade11ea4ee45433d97bf5eada22c4320c27df79c3a6a7eb1bf3ecfc47f2c997d9e5e2672fd
+"shell-quote@npm:1.8.4":
+  version: 1.8.4
+  resolution: "shell-quote@npm:1.8.4"
+  checksum: 10c0/86c93678bc394cb81f5ddcdc87df9c95d279ef9652775cd1cd1eed361404169a8d8cbaacaeed232ab09919e36ee1e5363863570390d78571f8c22b7f6312fb40
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Pins `shell-quote` to `1.8.4` via yarn `resolutions` to address [GHSA-w7jw-789q-3m8p](https://github.com/advisories/GHSA-w7jw-789q-3m8p) (shell command injection via unescaped newlines in `.op` values)
- The direct dependency `concurrently@9.2.1` pins `shell-quote` to exactly `1.8.3` (vulnerable) with no newer version available in Artifactory, making a resolution override the only viable fix

## Details

`shell-quote`'s `quote()` function did not escape line terminators (`\n`, `\r`) in object token `.op` values, allowing shell command injection when callers pass object tokens with attacker-influenced `.op` values. Fixed in `1.8.4` via an allowlist-based validation of `.op` values.

**Vulnerability:** GHSA-w7jw-789q-3m8p · Severity: Medium  
**Closes:** APEJSM-497

## Test plan

- [x] `yarn why shell-quote` confirms `1.8.4` is resolved
- [ ] CI passes